### PR TITLE
ZCS-5179 Add basic support for active sync performance testing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -50,10 +50,10 @@
             resultlog="${logs}/generic-caldav-requests.log"> 
       <property name="ACCOUNTS.csv" value="${users}"/>
       <property name="PROFILE.CalDAV.appointments" value="${basedir}/tests/generic/caldav/profiles/appointments.csv"/>
-      <property name="user.classpath" value="${zjmeter}"/>
+      <property name="user.classpath" value="${zjmeter}:src/build/jar/zm-sync-common.jar"/>
       <jmeterarg value="-q${basedir}/${env}"/>
-      <jmeterarg value="-q${basedir}/tests/generic/caldav/load.prop"/>
-      <jmeterarg value="-q${basedir}/tests/generic/caldav/profiles/basic.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/eas/load.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/eas/profiles/basic.prop"/>
     </jmeter>
   </target>
   <target name="generic-carddav" depends="src,logs">
@@ -67,6 +67,18 @@
       <jmeterarg value="-q${basedir}/${env}"/>
       <jmeterarg value="-q${basedir}/tests/generic/carddav/load.prop"/>
       <jmeterarg value="-q${basedir}/tests/generic/carddav/profiles/basic.prop"/>
+    </jmeter>
+  </target>
+  <target name="generic-eas" depends="src,logs">
+    <jmeter jmeterhome="${jmeter.home}"
+            testplan="${basedir}/tests/generic/eas/eas.jmx"
+            jmeterlogfile="${logs}/generic-eas-jmeter.log"
+            resultlog="${logs}/generic-eas-requests.log"> 
+      <property name="ACCOUNTS.csv" value="${users}"/>
+      <property name="user.classpath" value="${zjmeter}"/>
+      <jmeterarg value="-q${basedir}/${env}"/>
+      <jmeterarg value="-q${basedir}/tests/generic/zsoap/load.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/zsoap/profiles/basic.prop"/>
     </jmeter>
   </target>
   <target name="generic-imap" depends="src,logs">

--- a/build.xml
+++ b/build.xml
@@ -229,11 +229,11 @@
     <ant dir="src" antfile="build.xml" target="clean"/>
   </target>
   <target name="zm-sync-common-test">
-    <availabe file="src/build/jar/zm-sync-common.jar"
+    <available file="src/build/jar/zm-sync-common.jar"
               property="zm-sync-common-jar.present"/>
   </target>
   <target name="zm-sync-common" depends="zm-sync-common-test"
-          unless="jar.present">
-    <fail message="generic-eas test can not be run uncless zm-sync-common.jar is copied to src/build/jar manually"/>
+          unless="zm-sync-common-jar.present">
+    <fail message="generic-eas test can not be run unless zm-sync-common.jar is copied to src/build/jar manually"/>
   </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -50,10 +50,10 @@
             resultlog="${logs}/generic-caldav-requests.log"> 
       <property name="ACCOUNTS.csv" value="${users}"/>
       <property name="PROFILE.CalDAV.appointments" value="${basedir}/tests/generic/caldav/profiles/appointments.csv"/>
-      <property name="user.classpath" value="${zjmeter}:src/build/jar/zm-sync-common.jar"/>
+      <property name="user.classpath" value="${zjmeter}"/>
       <jmeterarg value="-q${basedir}/${env}"/>
-      <jmeterarg value="-q${basedir}/tests/generic/eas/load.prop"/>
-      <jmeterarg value="-q${basedir}/tests/generic/eas/profiles/basic.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/caldav/load.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/caldav/profiles/basic.prop"/>
     </jmeter>
   </target>
   <target name="generic-carddav" depends="src,logs">
@@ -69,13 +69,13 @@
       <jmeterarg value="-q${basedir}/tests/generic/carddav/profiles/basic.prop"/>
     </jmeter>
   </target>
-  <target name="generic-eas" depends="src,logs">
+  <target name="generic-eas" depends="src,logs,zm-sync-common">
     <jmeter jmeterhome="${jmeter.home}"
             testplan="${basedir}/tests/generic/eas/eas.jmx"
             jmeterlogfile="${logs}/generic-eas-jmeter.log"
             resultlog="${logs}/generic-eas-requests.log"> 
       <property name="ACCOUNTS.csv" value="${users}"/>
-      <property name="user.classpath" value="${zjmeter}"/>
+      <property name="user.classpath" value="${zjmeter}:${basedir}/src/build/jar/zm-sync-common.jar"/>
       <jmeterarg value="-q${basedir}/${env}"/>
       <jmeterarg value="-q${basedir}/tests/generic/eas/load.prop"/>
       <jmeterarg value="-q${basedir}/tests/generic/eas/profiles/basic.prop"/>
@@ -227,5 +227,13 @@
   <target name="clean">
     <delete dir="${logs}"/>
     <ant dir="src" antfile="build.xml" target="clean"/>
+  </target>
+  <target name="zm-sync-common-test">
+    <availabe file="src/build/jar/zm-sync-common.jar"
+              property="zm-sync-common-jar.present"/>
+  </target>
+  <target name="zm-sync-common" depends="zm-sync-common-test"
+          unless="jar.present">
+    <fail message="generic-eas test can not be run uncless zm-sync-common.jar is copied to src/build/jar manually"/>
   </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -77,8 +77,8 @@
       <property name="ACCOUNTS.csv" value="${users}"/>
       <property name="user.classpath" value="${zjmeter}"/>
       <jmeterarg value="-q${basedir}/${env}"/>
-      <jmeterarg value="-q${basedir}/tests/generic/zsoap/load.prop"/>
-      <jmeterarg value="-q${basedir}/tests/generic/zsoap/profiles/basic.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/eas/load.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/eas/profiles/basic.prop"/>
     </jmeter>
   </target>
   <target name="generic-imap" depends="src,logs">

--- a/config/env.prop
+++ b/config/env.prop
@@ -18,5 +18,5 @@ POP.server=zmc-proxy
 POP.domain=zmc.com
 POP.port=110
 EAS.version=12.1
-EMAIL.COUNT=10
-USER.COUNT=5
+EMAIL.COUNT=1
+USER.COUNT=1

--- a/config/env.prop
+++ b/config/env.prop
@@ -17,5 +17,6 @@ IMAP.port=143
 POP.server=zmc-proxy
 POP.domain=zmc.com
 POP.port=110
+EAS.version=12.1
 EMAIL.COUNT=10
 USER.COUNT=5

--- a/tests/generic/README.md
+++ b/tests/generic/README.md
@@ -13,6 +13,10 @@ The following protocols currently have a basic level of support:
 * carddav
   
   [vCard Extension to WebDAV](https://tools.ietf.org/html/rfc6352) view [carddav](carddav/carddav.md) for a list of currently supported commands in the jmx.
+
+* eas
+
+  [Exchange ActiveSync: Command Reference Protocol](https://msdn.microsoft.com/en-us/library/dd299441(v=exchg.80).aspx) [Exchange ActiveSync: HTTP Protocol](https://msdn.microsoft.com/en-us/library/dd299446(v=exchg.80).aspx) [Exchange ActiveSync: WAP Binary XML (WBXML) Algorithm](https://msdn.microsoft.com/en-us/library/dd299442(v=exchg.80).aspx) view [eas](eas/eas.md) for a list of currently suported commands in the jmx.
   
 * imap
   
@@ -46,6 +50,7 @@ For each of the supported generic tests they depend on a protocol
 |---------|--------|--------|
 |caldav   |CalDAV  |HTTP    |
 |carddav  |CardDAV |HTTP    |
+|eas      |EAS     |HTTP    |
 |imap     |IMAP    |IMAP    |
 |lmtp     |LMTP    |LMTP    |
 |pop      |POP     |POP     |

--- a/tests/generic/README.md
+++ b/tests/generic/README.md
@@ -16,7 +16,7 @@ The following protocols currently have a basic level of support:
 
 * eas
 
-  [Exchange ActiveSync: Command Reference Protocol](https://msdn.microsoft.com/en-us/library/dd299441(v=exchg.80).aspx) [Exchange ActiveSync: HTTP Protocol](https://msdn.microsoft.com/en-us/library/dd299446(v=exchg.80).aspx) [Exchange ActiveSync: WAP Binary XML (WBXML) Algorithm](https://msdn.microsoft.com/en-us/library/dd299442(v=exchg.80).aspx) view [eas](eas/eas.md) for a list of currently suported commands in the jmx.
+  [Exchange ActiveSync: Command Reference Protocol](https://msdn.microsoft.com/en-us/library/dd299441(v=exchg.80).aspx) [Exchange ActiveSync: HTTP Protocol](https://msdn.microsoft.com/en-us/library/dd299446(v=exchg.80).aspx) [Exchange ActiveSync: WAP Binary XML (WBXML) Algorithm](https://msdn.microsoft.com/en-us/library/dd299442(v=exchg.80).aspx) view [eas](eas/eas.md) for a list of currently suported commands in the jmx. This test depends on zm-sync-common.jar and assumes it is in src/build/jar.
   
 * imap
   

--- a/tests/generic/eas/eas.jmx
+++ b/tests/generic/eas/eas.jmx
@@ -271,7 +271,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -380,7 +380,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -478,7 +478,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -575,7 +575,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -646,7 +646,7 @@ SampleResult.setResponseData(result);
               </BeanShellSampler>
               <hashTree/>
               <SwitchController guiclass="SwitchControllerGui" testclass="SwitchController" testname="SendMail" enabled="true">
-                <stringProp name="SwitchController.value">${__P(EAS.version)}</stringProp>
+                <stringProp name="SwitchController.value">${__P(EAS.version,12.1)}</stringProp>
               </SwitchController>
               <hashTree>
                 <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="default" enabled="true">
@@ -683,7 +683,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;message/rfc822&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 HttpEntity entity = new StringEntity(message);
 hp.setEntity(entity);
@@ -768,7 +768,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -861,7 +861,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -950,7 +950,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.getProperty(&quot;EAS.version&quot;,&quot;12.1&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();

--- a/tests/generic/eas/eas.jmx
+++ b/tests/generic/eas/eas.jmx
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="2.9" jmeter="3.0 r1743807">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ResultCollector guiclass="SimpleDataWriter" testclass="ResultCollector" testname="Simple Data Writer" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>false</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>false</threadName>
+            <dataType>false</dataType>
+            <encoding>false</encoding>
+            <assertions>false</assertions>
+            <subresults>false</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <url>true</url>
+          </value>
+        </objProp>
+        <objProp>
+          <name></name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>false</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>false</threadName>
+            <dataType>false</dataType>
+            <encoding>false</encoding>
+            <assertions>false</assertions>
+            <subresults>false</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>true</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename">${__P(jmetercsv,${__P(REQUEST.log)})}</stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <boolProp name="ResultCollector.error_logging">false</boolProp>
+        <objProp>
+          <name>saveConfig</name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <objProp>
+          <name></name>
+          <value class="SampleSaveConfiguration">
+            <time>true</time>
+            <latency>true</latency>
+            <timestamp>true</timestamp>
+            <success>true</success>
+            <label>true</label>
+            <code>true</code>
+            <message>true</message>
+            <threadName>true</threadName>
+            <dataType>true</dataType>
+            <encoding>false</encoding>
+            <assertions>true</assertions>
+            <subresults>true</subresults>
+            <responseData>false</responseData>
+            <samplerData>false</samplerData>
+            <xml>false</xml>
+            <fieldNames>false</fieldNames>
+            <responseHeaders>false</responseHeaders>
+            <requestHeaders>false</requestHeaders>
+            <responseDataOnError>false</responseDataOnError>
+            <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+            <assertionsResultsToSave>0</assertionsResultsToSave>
+            <bytes>true</bytes>
+            <threadCounts>true</threadCounts>
+          </value>
+        </objProp>
+        <stringProp name="filename"></stringProp>
+      </ResultCollector>
+      <hashTree/>
+      <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="Accounts" enabled="true">
+        <stringProp name="filename">${__P(ACCOUNTS.csv)}</stringProp>
+        <stringProp name="fileEncoding"></stringProp>
+        <stringProp name="variableNames">USER,PASS</stringProp>
+        <stringProp name="delimiter">,</stringProp>
+        <boolProp name="quotedData">false</boolProp>
+        <boolProp name="recycle">true</boolProp>
+        <boolProp name="stopThread">false</boolProp>
+        <stringProp name="shareMode">shareMode.all</stringProp>
+      </CSVDataSet>
+      <hashTree/>
+      <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="EAS Setup" enabled="true">
+        <stringProp name="filename"></stringProp>
+        <stringProp name="parameters"></stringProp>
+        <boolProp name="resetInterpreter">false</boolProp>
+        <stringProp name="script">import com.zimbra.jmeter.Zimbra;
+//debug();
+Zimbra eas = new Zimbra(props,&quot;EAS&quot;);
+vars.putObject(&quot;EAS&quot;,eas);</stringProp>
+      </BeanShellPreProcessor>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="EAS" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${__P(LOAD.EAS.loopcount)}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(LOAD.EAS.users)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${__P(LOAD.EAS.rampup)}</stringProp>
+        <longProp name="ThreadGroup.start_time">1505165237000</longProp>
+        <longProp name="ThreadGroup.end_time">1505165237000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration">${__P(LOAD.EAS.duration)}</stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="EAS Settings" enabled="true">
+          <collectionProp name="Arguments.arguments">
+            <elementProp name="EASURL" elementType="Argument">
+              <stringProp name="Argument.name">EASURL</stringProp>
+              <stringProp name="Argument.value">/Microsoft-Server-ActiveSync?Cmd=${COMMAND}&amp;User=${USER}&amp;DeviceId=testing&amp;DeviceType=jmeter</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="SYNCKEY" elementType="Argument">
+              <stringProp name="Argument.name">SYNCKEY</stringProp>
+              <stringProp name="Argument.value">0</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+          </collectionProp>
+        </Arguments>
+        <hashTree/>
+        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="EAS HTTP Config" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">${__P(HTTP.server)}</stringProp>
+          <stringProp name="HTTPSampler.port">${__P(HTTP.port)}</stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol">${__P(HTTP.protocol)}</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/Microsoft-Server-ActiveSync</stringProp>
+          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
+          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
+        </ConfigTestElement>
+        <hashTree/>
+        <AuthManager guiclass="AuthPanel" testclass="AuthManager" testname="EAS Authentication" enabled="true">
+          <collectionProp name="AuthManager.auth_list">
+            <elementProp name="" elementType="Authorization">
+              <stringProp name="Authorization.url">https://${__P(HTTP.server)}</stringProp>
+              <stringProp name="Authorization.username">${USER}</stringProp>
+              <stringProp name="Authorization.password">${PASS}</stringProp>
+              <stringProp name="Authorization.domain"></stringProp>
+              <stringProp name="Authorization.realm"></stringProp>
+            </elementProp>
+          </collectionProp>
+        </AuthManager>
+        <hashTree/>
+        <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="START" enabled="true">
+          <stringProp name="BeanShellSampler.query">import com.zimbra.jmeter.Zimbra;
+import com.zimbra.jmeter.Command;
+
+Zimbra eas = vars.getObject(&quot;EAS&quot;);
+ArrayList commands = eas.getcommands();
+
+vars.putObject(&quot;COMMANDS&quot;,commands);
+// generate command DELAY
+if (props.get(&quot;LOAD.EAS.userduration&quot;) == null || commands.size() == 0) {
+  vars.putObject(&quot;DELAY&quot;,&quot;0&quot;);
+} else {
+  int delay = Integer.parseInt(props.get(&quot;LOAD.EAS.userduration&quot;))*1000/commands.size();
+  vars.putObject(&quot;DELAY&quot;,delay.toString());
+}
+// initialize CONTINUE
+if (commands.size() &gt; 0) {
+  vars.put(&quot;CONTINUE&quot;,&quot;true&quot;);
+} else {
+  vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
+}</stringProp>
+          <stringProp name="BeanShellSampler.filename"></stringProp>
+          <stringProp name="BeanShellSampler.parameters"></stringProp>
+          <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+        </BeanShellSampler>
+        <hashTree/>
+        <WhileController guiclass="WhileControllerGui" testclass="WhileController" testname="Run Commands" enabled="true">
+          <stringProp name="WhileController.condition">${__BeanShell(&quot;${CONTINUE}&quot;.equals(&quot;true&quot;))}</stringProp>
+        </WhileController>
+        <hashTree>
+          <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="Next Command" enabled="true">
+            <stringProp name="BeanShellSampler.query">import com.zimbra.jmeter.Command;
+
+ArrayList commands = vars.getObject(&quot;COMMANDS&quot;);
+if (commands.size() &gt; 0) {
+  //log.info(&quot;Testing: &quot;+commands);
+  Command c = commands.remove(0);
+  vars.put(&quot;COMMAND&quot;,c.getName());
+  for (Map.Entry a: c.argsSet()) {
+  	vars.put(a.getKey(),a.getValue());
+  }
+  //log.info(vars.get(&quot;COMMAND&quot;));
+}
+if (commands.size() == 0) {
+  vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
+}</stringProp>
+            <stringProp name="BeanShellSampler.filename"></stringProp>
+            <stringProp name="BeanShellSampler.parameters"></stringProp>
+            <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+          </BeanShellSampler>
+          <hashTree/>
+          <TransactionController guiclass="TransactionControllerGui" testclass="TransactionController" testname="Command Execution" enabled="true">
+            <boolProp name="TransactionController.includeTimers">false</boolProp>
+            <boolProp name="TransactionController.parent">false</boolProp>
+          </TransactionController>
+          <hashTree>
+            <ConstantTimer guiclass="ConstantTimerGui" testclass="ConstantTimer" testname="Command Delay" enabled="true">
+              <stringProp name="ConstantTimer.delay">${DELAY}</stringProp>
+            </ConstantTimer>
+            <hashTree/>
+            <SwitchController guiclass="SwitchControllerGui" testclass="SwitchController" testname="Commands" enabled="true">
+              <stringProp name="SwitchController.value">${COMMAND}</stringProp>
+            </SwitchController>
+            <hashTree>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="default" enabled="true">
+                <stringProp name="BeanShellSampler.query">log.info(Thread.currentThread().getName()+&quot; &quot;+vars.get(&quot;COMMAND&quot;)+&quot; not currently supported&quot;);</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree/>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="FolderCreate" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=FolderCreate&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = &quot;user1:userpass&quot;;
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;2.5&quot;);
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_FOLDERCREATE);
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;SYNCKEY&quot;));
+bs.integerElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_PARENTID,0);
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_DISPLAYNAME,&quot;ActiveSyncTestDir&quot;);
+bs.integerElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_TYPE,12);
+bs.closeTag();
+
+//Add WBXML Body to request
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+//Disable SSL validation/verification
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+//Create http connection and send request
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (e) {
+   log.info(&quot;FolderCreate exception thrown: &quot;+e);
+}
+SampleResult.setResponseData(result);
+
+} catch (Exception e) {
+	log.error(e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default">${SYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default"></stringProp>
+                  <stringProp name="XPathExtractor.refname">FOLDERID</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//ServerId</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="FolderDelete" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+
+try {
+HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=FolderDelete&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = &quot;user1:userpass&quot;;
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;2.5&quot;);
+
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_FOLDERDELETE);
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;SYNCKEY&quot;));
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SERVERID,vars.get(&quot;FOLDERID&quot;));
+bs.closeTag();
+
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Generate readable result data
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (e) {
+   log.info(&quot;FolderDelete exception thrown: &quot;+e);
+}
+SampleResult.setResponseData(result);
+
+} catch (Exception e) {
+	log.error(e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default">${SYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="FolderSync" enabled="true">
+                <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+                <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                  <collectionProp name="Arguments.arguments">
+                    <elementProp name="" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">&lt;?xmll version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xd;
+&lt;FolderSync xmlns=&quot;FolderHierarchy&quot;&gt;&#xd;
+  &lt;SyncKey&gt;${SYNCKEY}&lt;/SyncKey&gt;&#xd;
+&lt;/FolderSync&gt;</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                    </elementProp>
+                  </collectionProp>
+                </elementProp>
+                <stringProp name="HTTPSampler.domain"></stringProp>
+                <stringProp name="HTTPSampler.port"></stringProp>
+                <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+                <stringProp name="HTTPSampler.response_timeout"></stringProp>
+                <stringProp name="HTTPSampler.protocol"></stringProp>
+                <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+                <stringProp name="HTTPSampler.path">${__eval(${EASURL})}</stringProp>
+                <stringProp name="HTTPSampler.method">POST</stringProp>
+                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+                <boolProp name="HTTPSampler.monitor">false</boolProp>
+                <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              </HTTPSamplerProxy>
+              <hashTree>
+                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
+                  <boolProp name="resetInterpreter">false</boolProp>
+                  <stringProp name="parameters"></stringProp>
+                  <stringProp name="filename"></stringProp>
+                  <stringProp name="script">import com.zimbra.zimbrasync.wbxml.BinaryParser;
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(data),false);
+
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (e) {
+   log.info(&quot;FolderSync exception thrown: &quot;+e);
+}
+prev.setResponseData(result);</stringProp>
+                </BeanShellPostProcessor>
+                <hashTree/>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default"></stringProp>
+                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="false">
+                  <boolProp name="resetInterpreter">false</boolProp>
+                  <stringProp name="parameters"></stringProp>
+                  <stringProp name="filename"></stringProp>
+                  <stringProp name="script">String synckey=vars.get(&quot;SYNCKEY&quot;);
+log.info(&quot;SYNCKEY: &quot;+synckey);
+synckey=synckey.replaceAll(&quot;\\{.*\\}&quot;,&quot;&quot;);
+log.info(&quot;SYNCKEY: &quot;+synckey);
+vars.put(&quot;SYNCKEY&quot;,&quot;1&quot;);</stringProp>
+                </BeanShellPostProcessor>
+                <hashTree/>
+              </hashTree>
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Search" enabled="true">
+                <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+                <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+                  <collectionProp name="Arguments.arguments">
+                    <elementProp name="" elementType="HTTPArgument">
+                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                      <stringProp name="Argument.value">&lt;?xmll version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xd;
+&lt;Search xmlns=&quot;Search&quot;&gt;&#xd;
+  &lt;Store&gt;&#xd;
+    &lt;Name&gt;Mailbox&lt;/Name&gt;&#xd;
+    &lt;Query&gt;Testing&lt;/Query&gt;&#xd;
+    &lt;Options&gt;&#xd;
+      &lt;Range&gt;0-10&lt;/Range&gt;&#xd;
+    &lt;/Options&gt;&#xd;
+  &lt;/Store&gt;&#xd;
+&lt;/Search&gt;</stringProp>
+                      <stringProp name="Argument.metadata">=</stringProp>
+                    </elementProp>
+                  </collectionProp>
+                </elementProp>
+                <stringProp name="HTTPSampler.domain"></stringProp>
+                <stringProp name="HTTPSampler.port"></stringProp>
+                <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+                <stringProp name="HTTPSampler.response_timeout"></stringProp>
+                <stringProp name="HTTPSampler.protocol"></stringProp>
+                <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+                <stringProp name="HTTPSampler.path">${__eval(${EASURL})}</stringProp>
+                <stringProp name="HTTPSampler.method">POST</stringProp>
+                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+                <boolProp name="HTTPSampler.monitor">false</boolProp>
+                <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              </HTTPSamplerProxy>
+              <hashTree>
+                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
+                  <boolProp name="resetInterpreter">false</boolProp>
+                  <stringProp name="parameters"></stringProp>
+                  <stringProp name="filename"></stringProp>
+                  <stringProp name="script">import com.zimbra.zimbrasync.wbxml.BinaryParser;
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(data),false);
+
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (e) {
+   log.info(&quot;Exception thrown: &quot;+e);
+}
+prev.setResponseData(result);</stringProp>
+                </BeanShellPostProcessor>
+                <hashTree/>
+              </hashTree>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="Search2" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+log.info(&quot;Search start&quot;);
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=Search&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = &quot;user1:userpass&quot;;
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;2.5&quot;);
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_SEARCH);
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_STORE);
+bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_NAME,&quot;Mailbox&quot;);
+bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_QUERY,&quot;test&quot;);
+bs.closeTag();
+bs.closeTag();
+log.info(&quot;Search Inside&quot;);
+
+//Add WBXML Body to request
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+//Disable SSL validation/verification
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+//Create http connection and send request
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+log.info(&quot;Search result&quot;);
+//Convert WBXML to readable form for jmeter
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (e) {
+   log.info(&quot;Search exception thrown: &quot;+e);
+}
+SampleResult.setResponseData(result);
+
+} catch (Exception e) {
+	log.error(&quot;Search:&quot;+e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree/>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="SendMail" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+
+String message = &quot;From: &lt;user1@zimbra07.loadtest.synacor.com&gt;\n&quot;;
+message += &quot;To: &lt;user1@zimbra07.loadtest.synacor.com&gt;\n&quot;;
+message += &quot;Subject: From Active Sync\n&quot;;
+message += &quot;MIME-Version: 1.0\n&quot;;
+message += &quot;Content-Type:  text/plain; charset=utf-8\n&quot;;
+message += &quot;Content-Transfer-Encoding: 7bit\n\n&quot;;
+message += &quot;This is the message.\n&quot;;
+
+try {
+HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=SendMail&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = &quot;user1:userpass&quot;;
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_SENDMAIL);
+bs.textElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_CLIENTID,&quot;${__UUID()}&quot;);
+bs.opaqueElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_MIME,message);
+bs.closeTag();
+
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+log.info(&quot;SendMail Status: &quot;+hr.getStatusLine());
+} catch (Exception e) {
+	log.error(e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree/>
+              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Sync" enabled="true">
+                <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+                  <collectionProp name="Arguments.arguments"/>
+                </elementProp>
+                <stringProp name="HTTPSampler.domain"></stringProp>
+                <stringProp name="HTTPSampler.port"></stringProp>
+                <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+                <stringProp name="HTTPSampler.response_timeout"></stringProp>
+                <stringProp name="HTTPSampler.protocol"></stringProp>
+                <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+                <stringProp name="HTTPSampler.path">${__eval(${EASURL})}</stringProp>
+                <stringProp name="HTTPSampler.method">POST</stringProp>
+                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+                <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+                <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+                <boolProp name="HTTPSampler.monitor">false</boolProp>
+                <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+              </HTTPSamplerProxy>
+              <hashTree>
+                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
+                  <boolProp name="resetInterpreter">false</boolProp>
+                  <stringProp name="parameters"></stringProp>
+                  <stringProp name="filename"></stringProp>
+                  <stringProp name="script">import com.zimbra.zimbrasync.wbxml.BinaryParser;
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(data),false);
+
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (e) {
+   log.info(&quot;Sync exception thrown: &quot;+e);
+}
+prev.setResponseData(result);</stringProp>
+                </BeanShellPostProcessor>
+                <hashTree/>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default">${SYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
+            </hashTree>
+          </hashTree>
+        </hashTree>
+        <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="true">
+          <boolProp name="displayJMeterProperties">true</boolProp>
+          <boolProp name="displayJMeterVariables">true</boolProp>
+          <boolProp name="displaySystemProperties">true</boolProp>
+        </DebugSampler>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+    <WorkBench guiclass="WorkBenchGui" testclass="WorkBench" testname="WorkBench" enabled="true">
+      <boolProp name="WorkBench.save">true</boolProp>
+    </WorkBench>
+    <hashTree/>
+  </hashTree>
+</jmeterTestPlan>

--- a/tests/generic/eas/eas.jmx
+++ b/tests/generic/eas/eas.jmx
@@ -144,16 +144,6 @@
         <stringProp name="shareMode">shareMode.all</stringProp>
       </CSVDataSet>
       <hashTree/>
-      <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="EAS Setup" enabled="true">
-        <stringProp name="filename"></stringProp>
-        <stringProp name="parameters"></stringProp>
-        <boolProp name="resetInterpreter">false</boolProp>
-        <stringProp name="script">import com.zimbra.jmeter.Zimbra;
-//debug();
-Zimbra eas = new Zimbra(props,&quot;EAS&quot;);
-vars.putObject(&quot;EAS&quot;,eas);</stringProp>
-      </BeanShellPreProcessor>
-      <hashTree/>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="EAS" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
@@ -171,49 +161,33 @@ vars.putObject(&quot;EAS&quot;,eas);</stringProp>
       <hashTree>
         <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="EAS Settings" enabled="true">
           <collectionProp name="Arguments.arguments">
-            <elementProp name="EASURL" elementType="Argument">
-              <stringProp name="Argument.name">EASURL</stringProp>
-              <stringProp name="Argument.value">/Microsoft-Server-ActiveSync?Cmd=${COMMAND}&amp;User=${USER}&amp;DeviceId=testing&amp;DeviceType=jmeter</stringProp>
+            <elementProp name="FOLDERSYNCKEY" elementType="Argument">
+              <stringProp name="Argument.name">FOLDERSYNCKEY</stringProp>
+              <stringProp name="Argument.value">0</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
-            <elementProp name="SYNCKEY" elementType="Argument">
-              <stringProp name="Argument.name">SYNCKEY</stringProp>
+            <elementProp name="SYNCSYNCKEY" elementType="Argument">
+              <stringProp name="Argument.name">SYNCSYNCKEY</stringProp>
               <stringProp name="Argument.value">0</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
           </collectionProp>
         </Arguments>
         <hashTree/>
-        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="EAS HTTP Config" enabled="true">
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
-          </elementProp>
-          <stringProp name="HTTPSampler.domain">${__P(HTTP.server)}</stringProp>
-          <stringProp name="HTTPSampler.port">${__P(HTTP.port)}</stringProp>
-          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-          <stringProp name="HTTPSampler.response_timeout"></stringProp>
-          <stringProp name="HTTPSampler.protocol">${__P(HTTP.protocol)}</stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/Microsoft-Server-ActiveSync</stringProp>
-          <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
-          <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
-        </ConfigTestElement>
-        <hashTree/>
-        <AuthManager guiclass="AuthPanel" testclass="AuthManager" testname="EAS Authentication" enabled="true">
-          <collectionProp name="AuthManager.auth_list">
-            <elementProp name="" elementType="Authorization">
-              <stringProp name="Authorization.url">https://${__P(HTTP.server)}</stringProp>
-              <stringProp name="Authorization.username">${USER}</stringProp>
-              <stringProp name="Authorization.password">${PASS}</stringProp>
-              <stringProp name="Authorization.domain"></stringProp>
-              <stringProp name="Authorization.realm"></stringProp>
-            </elementProp>
-          </collectionProp>
-        </AuthManager>
-        <hashTree/>
         <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="START" enabled="true">
           <stringProp name="BeanShellSampler.query">import com.zimbra.jmeter.Zimbra;
 import com.zimbra.jmeter.Command;
+
+Zimbra eas = new Zimbra(props,&quot;EAS&quot;);
+vars.putObject(&quot;EAS&quot;,eas);
+
+String url = props.get(&quot;HTTP.protocol&quot;)+&quot;://&quot;+props.get(&quot;HTTP.server&quot;);
+if (!props.get(&quot;HTTP.port&quot;).equals(&quot;&quot;) ) {
+  url = url + &quot;:&quot; + props.get(&quot;HTTP.port&quot;); 
+}
+url = url+&quot;/Microsoft-Server-ActiveSync&quot;;
+//log.info(&quot;EAS URL: &quot;+url);
+vars.put(&quot;URL&quot;,url);
 
 Zimbra eas = vars.getObject(&quot;EAS&quot;);
 ArrayList commands = eas.getcommands();
@@ -302,19 +276,20 @@ import com.zimbra.zimbrasync.wbxml.BinaryParser;
 
 try {
 //Setup HTTP Request
-HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=FolderCreate&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = &quot;user1:userpass&quot;;
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;2.5&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
 BinarySerializer bs = new BinarySerializer(bao,false);
 bs.openTag(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_FOLDERCREATE);
-bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;SYNCKEY&quot;));
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;FOLDERSYNCKEY&quot;));
 bs.integerElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_PARENTID,0);
 bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_DISPLAYNAME,&quot;ActiveSyncTestDir&quot;);
 bs.integerElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_TYPE,12);
@@ -341,7 +316,6 @@ ResponseMessage = hr.getStatusLine().getReasonPhrase();
 String result=&quot;&quot;;
 try {
   BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
-
   while (bp.next() != null) {
     if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
       result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
@@ -355,13 +329,17 @@ try {
       result+=bp.getText(); 	
     }
   }
-} catch (e) {
-   log.info(&quot;FolderCreate exception thrown: &quot;+e);
+} catch (IOException e) {
+  if (e.getMessage().equals(&quot;Unexpected EOF&quot;)) {
+  	// ignore
+  } else {
+  	throw e;
+  }
 }
 SampleResult.setResponseData(result);
 
 } catch (Exception e) {
-	log.error(e.toString());
+	log.error(&quot;FolderCreate: &quot;+e.toString());
 }</stringProp>
                 <stringProp name="BeanShellSampler.filename"></stringProp>
                 <stringProp name="BeanShellSampler.parameters"></stringProp>
@@ -369,8 +347,8 @@ SampleResult.setResponseData(result);
               </BeanShellSampler>
               <hashTree>
                 <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
-                  <stringProp name="XPathExtractor.default">${SYNCKEY}</stringProp>
-                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.default">${FOLDERSYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">FOLDERSYNCKEY</stringProp>
                   <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
                   <boolProp name="XPathExtractor.validate">false</boolProp>
                   <boolProp name="XPathExtractor.tolerant">false</boolProp>
@@ -406,255 +384,23 @@ import com.zimbra.zimbrasync.wbxml.BinaryParser;
 
 
 try {
-HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=FolderDelete&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = &quot;user1:userpass&quot;;
-byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
-String authHeader = &quot;Basic &quot;+new String(encodedAuth);
-hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
-hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;2.5&quot;);
-
-ByteArrayOutputStream bao = new ByteArrayOutputStream();
-BinarySerializer bs = new BinarySerializer(bao,false);
-bs.openTag(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_FOLDERDELETE);
-bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;SYNCKEY&quot;));
-bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SERVERID,vars.get(&quot;FOLDERID&quot;));
-bs.closeTag();
-
-HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
-hp.setEntity(entity);
-
-SSLContextBuilder builder = new SSLContextBuilder();
-builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
-SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-
-CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
-HttpResponse hr = dhc.execute(hp);
-
-//Generate readable result data
-String result=&quot;&quot;;
-try {
-  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
-
-  while (bp.next() != null) {
-    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
-    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.START_TAG) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.END_TAG) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.TEXT) {
-      result+=bp.getText(); 	
-    }
-  }
-} catch (e) {
-   log.info(&quot;FolderDelete exception thrown: &quot;+e);
-}
-SampleResult.setResponseData(result);
-
-} catch (Exception e) {
-	log.error(e.toString());
-}</stringProp>
-                <stringProp name="BeanShellSampler.filename"></stringProp>
-                <stringProp name="BeanShellSampler.parameters"></stringProp>
-                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
-              </BeanShellSampler>
-              <hashTree>
-                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
-                  <stringProp name="XPathExtractor.default">${SYNCKEY}</stringProp>
-                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
-                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
-                  <boolProp name="XPathExtractor.validate">false</boolProp>
-                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
-                  <boolProp name="XPathExtractor.namespace">false</boolProp>
-                </XPathExtractor>
-                <hashTree/>
-              </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="FolderSync" enabled="true">
-                <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-                <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-                  <collectionProp name="Arguments.arguments">
-                    <elementProp name="" elementType="HTTPArgument">
-                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">&lt;?xmll version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xd;
-&lt;FolderSync xmlns=&quot;FolderHierarchy&quot;&gt;&#xd;
-  &lt;SyncKey&gt;${SYNCKEY}&lt;/SyncKey&gt;&#xd;
-&lt;/FolderSync&gt;</stringProp>
-                      <stringProp name="Argument.metadata">=</stringProp>
-                    </elementProp>
-                  </collectionProp>
-                </elementProp>
-                <stringProp name="HTTPSampler.domain"></stringProp>
-                <stringProp name="HTTPSampler.port"></stringProp>
-                <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-                <stringProp name="HTTPSampler.response_timeout"></stringProp>
-                <stringProp name="HTTPSampler.protocol"></stringProp>
-                <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-                <stringProp name="HTTPSampler.path">${__eval(${EASURL})}</stringProp>
-                <stringProp name="HTTPSampler.method">POST</stringProp>
-                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-                <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-                <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-                <boolProp name="HTTPSampler.monitor">false</boolProp>
-                <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-              </HTTPSamplerProxy>
-              <hashTree>
-                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
-                  <boolProp name="resetInterpreter">false</boolProp>
-                  <stringProp name="parameters"></stringProp>
-                  <stringProp name="filename"></stringProp>
-                  <stringProp name="script">import com.zimbra.zimbrasync.wbxml.BinaryParser;
-String result=&quot;&quot;;
-try {
-  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(data),false);
-
-  while (bp.next() != null) {
-    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
-    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.START_TAG) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.END_TAG) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.TEXT) {
-      result+=bp.getText(); 	
-    }
-  }
-} catch (e) {
-   log.info(&quot;FolderSync exception thrown: &quot;+e);
-}
-prev.setResponseData(result);</stringProp>
-                </BeanShellPostProcessor>
-                <hashTree/>
-                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
-                  <stringProp name="XPathExtractor.default"></stringProp>
-                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
-                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
-                  <boolProp name="XPathExtractor.validate">false</boolProp>
-                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
-                  <boolProp name="XPathExtractor.namespace">false</boolProp>
-                </XPathExtractor>
-                <hashTree/>
-                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="false">
-                  <boolProp name="resetInterpreter">false</boolProp>
-                  <stringProp name="parameters"></stringProp>
-                  <stringProp name="filename"></stringProp>
-                  <stringProp name="script">String synckey=vars.get(&quot;SYNCKEY&quot;);
-log.info(&quot;SYNCKEY: &quot;+synckey);
-synckey=synckey.replaceAll(&quot;\\{.*\\}&quot;,&quot;&quot;);
-log.info(&quot;SYNCKEY: &quot;+synckey);
-vars.put(&quot;SYNCKEY&quot;,&quot;1&quot;);</stringProp>
-                </BeanShellPostProcessor>
-                <hashTree/>
-              </hashTree>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Search" enabled="true">
-                <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
-                <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
-                  <collectionProp name="Arguments.arguments">
-                    <elementProp name="" elementType="HTTPArgument">
-                      <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                      <stringProp name="Argument.value">&lt;?xmll version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;&#xd;
-&lt;Search xmlns=&quot;Search&quot;&gt;&#xd;
-  &lt;Store&gt;&#xd;
-    &lt;Name&gt;Mailbox&lt;/Name&gt;&#xd;
-    &lt;Query&gt;Testing&lt;/Query&gt;&#xd;
-    &lt;Options&gt;&#xd;
-      &lt;Range&gt;0-10&lt;/Range&gt;&#xd;
-    &lt;/Options&gt;&#xd;
-  &lt;/Store&gt;&#xd;
-&lt;/Search&gt;</stringProp>
-                      <stringProp name="Argument.metadata">=</stringProp>
-                    </elementProp>
-                  </collectionProp>
-                </elementProp>
-                <stringProp name="HTTPSampler.domain"></stringProp>
-                <stringProp name="HTTPSampler.port"></stringProp>
-                <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-                <stringProp name="HTTPSampler.response_timeout"></stringProp>
-                <stringProp name="HTTPSampler.protocol"></stringProp>
-                <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-                <stringProp name="HTTPSampler.path">${__eval(${EASURL})}</stringProp>
-                <stringProp name="HTTPSampler.method">POST</stringProp>
-                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-                <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-                <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-                <boolProp name="HTTPSampler.monitor">false</boolProp>
-                <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-              </HTTPSamplerProxy>
-              <hashTree>
-                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
-                  <boolProp name="resetInterpreter">false</boolProp>
-                  <stringProp name="parameters"></stringProp>
-                  <stringProp name="filename"></stringProp>
-                  <stringProp name="script">import com.zimbra.zimbrasync.wbxml.BinaryParser;
-String result=&quot;&quot;;
-try {
-  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(data),false);
-
-  while (bp.next() != null) {
-    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
-    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.START_TAG) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.END_TAG) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
-    } else if (bp.getEventType() == BinaryParser.TEXT) {
-      result+=bp.getText(); 	
-    }
-  }
-} catch (e) {
-   log.info(&quot;Exception thrown: &quot;+e);
-}
-prev.setResponseData(result);</stringProp>
-                </BeanShellPostProcessor>
-                <hashTree/>
-              </hashTree>
-              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="Search2" enabled="true">
-                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.conn.ssl.SSLContextBuilder;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.util.EntityUtils;
-import org.apache.commons.codec.binary.Base64;
-import java.nio.charset.StandardCharsets;
-import org.apache.http.HttpHeaders;
-import com.zimbra.zimbrasync.wbxml.BinarySerializer;
-import com.zimbra.zimbrasync.wbxml.BinaryParser;
-
-log.info(&quot;Search start&quot;);
-
-try {
 //Setup HTTP Request
-HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=Search&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = &quot;user1:userpass&quot;;
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;2.5&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
 BinarySerializer bs = new BinarySerializer(bao,false);
-bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_SEARCH);
-bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_STORE);
-bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_NAME,&quot;Mailbox&quot;);
-bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_QUERY,&quot;test&quot;);
+bs.openTag(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_FOLDERDELETE);
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;FOLDERSYNCKEY&quot;));
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SERVERID,vars.get(&quot;FOLDERID&quot;));
 bs.closeTag();
-bs.closeTag();
-log.info(&quot;Search Inside&quot;);
 
 //Add WBXML Body to request
 HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
@@ -673,12 +419,10 @@ HttpResponse hr = dhc.execute(hp);
 ResponseCode = hr.getStatusLine().getStatusCode();
 ResponseMessage = hr.getStatusLine().getReasonPhrase();
 
-log.info(&quot;Search result&quot;);
 //Convert WBXML to readable form for jmeter
 String result=&quot;&quot;;
 try {
   BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
-
   while (bp.next() != null) {
     if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
       result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
@@ -692,8 +436,214 @@ try {
       result+=bp.getText(); 	
     }
   }
-} catch (e) {
-   log.info(&quot;Search exception thrown: &quot;+e);
+} catch (IOException e) {
+  if (e.message.equals(&quot;Unexpected EOF&quot;)) {
+  	// ignore
+  } else {
+  	throw e;
+  }
+}
+SampleResult.setResponseData(result);
+
+} catch (Exception e) {
+	log.error(&quot;FolderDelete: &quot;+e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default">${FOLDERSYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">FOLDERSYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="FolderSync" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_FOLDERSYNC);
+bs.textElement(BinarySerializer.NAMESPACE_FOLDERHIERARCHY,BinarySerializer.FOLDERHIERARCHY_SYNCKEY,vars.get(&quot;FOLDERSYNCKEY&quot;));
+bs.closeTag();
+
+//Add WBXML Body to request
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+//Disable SSL validation/verification
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+//Create http connection and send request
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (IOException e) {
+  if (e.message.equals(&quot;Unexpected EOF&quot;)) {
+  	// ignore
+  } else {
+  	throw e;
+  }
+}
+SampleResult.setResponseData(result);
+
+} catch (Exception e) {
+	log.error(&quot;FolderSync: &quot;+e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
+                  <stringProp name="XPathExtractor.default">${FOLDERSYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">FOLDERSYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="Search" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_SEARCH);
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_STORE);
+bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_NAME,&quot;Mailbox&quot;);
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_QUERY);
+bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_FREETEXT,&quot;test&quot;);
+bs.closeTag();
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_OPTIONS);
+bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_RANGE,&quot;0-9&quot;);
+bs.closeTag();
+bs.closeTag();
+bs.closeTag();
+
+//Add WBXML Body to request
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+//Disable SSL validation/verification
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+//Create http connection and send request
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
+String result=&quot;&quot;;
+try {
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+  while (bp.next() != null) {
+    if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+    } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.START_TAG) {
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.END_TAG) {
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+    } else if (bp.getEventType() == BinaryParser.TEXT) {
+      result+=bp.getText(); 	
+    }
+  }
+} catch (IOException e) {
+  if (e.message.equals(&quot;Unexpected EOF&quot;)) {
+  	// ignore
+  } else {
+  	throw e;
+  }
 }
 SampleResult.setResponseData(result);
 
@@ -711,14 +661,16 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpEntity;
-import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
 import org.apache.commons.codec.binary.Base64;
 import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpHeaders;
 import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
 
 String message = &quot;From: &lt;user1@zimbra07.loadtest.synacor.com&gt;\n&quot;;
 message += &quot;To: &lt;user1@zimbra07.loadtest.synacor.com&gt;\n&quot;;
@@ -729,21 +681,17 @@ message += &quot;Content-Transfer-Encoding: 7bit\n\n&quot;;
 message += &quot;This is the message.\n&quot;;
 
 try {
-HttpPost hp = new HttpPost(&quot;https://10.250.3.127/Microsoft-Server-ActiveSync?Cmd=SendMail&amp;User=user1&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = &quot;user1:userpass&quot;;
+//Setup HTTP Request
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
-hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;Content-Type&quot;,&quot;message/rfc822&quot;);
 
-ByteArrayOutputStream bao = new ByteArrayOutputStream();
-BinarySerializer bs = new BinarySerializer(bao,false);
-bs.openTag(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_SENDMAIL);
-bs.textElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_CLIENTID,&quot;${__UUID()}&quot;);
-bs.opaqueElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_MIME,message);
-bs.closeTag();
-
-HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+HttpEntity entity = new StringEntity(message);
 hp.setEntity(entity);
 
 SSLContextBuilder builder = new SSLContextBuilder();
@@ -753,44 +701,107 @@ SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(
 CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
 HttpResponse hr = dhc.execute(hp);
 
-log.info(&quot;SendMail Status: &quot;+hr.getStatusLine());
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
+if (hr.getEntity().getContentLength() &gt; 0) {
+  String result=&quot;&quot;;
+  try {
+    BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+    while (bp.next() != null) {
+      if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+        result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+      } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+        result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.START_TAG) {
+        result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.END_TAG) {
+        result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.TEXT) {
+        result+=bp.getText(); 	
+      }
+    }
+  } catch (Exception e) {
+    if (e.getMessage().equals(&quot;Unexpected EOF&quot;)) {
+      // ignore
+    } else {
+      throw e;
+    }
+  }
+  SampleResult.setResponseData(result);
+}
 } catch (Exception e) {
-	log.error(e.toString());
+	log.error(&quot;SendMail exception: &quot;+e.toString());
 }</stringProp>
                 <stringProp name="BeanShellSampler.filename"></stringProp>
                 <stringProp name="BeanShellSampler.parameters"></stringProp>
                 <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
               </BeanShellSampler>
               <hashTree/>
-              <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Sync" enabled="true">
-                <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-                  <collectionProp name="Arguments.arguments"/>
-                </elementProp>
-                <stringProp name="HTTPSampler.domain"></stringProp>
-                <stringProp name="HTTPSampler.port"></stringProp>
-                <stringProp name="HTTPSampler.connect_timeout"></stringProp>
-                <stringProp name="HTTPSampler.response_timeout"></stringProp>
-                <stringProp name="HTTPSampler.protocol"></stringProp>
-                <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-                <stringProp name="HTTPSampler.path">${__eval(${EASURL})}</stringProp>
-                <stringProp name="HTTPSampler.method">POST</stringProp>
-                <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
-                <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
-                <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
-                <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
-                <boolProp name="HTTPSampler.monitor">false</boolProp>
-                <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-              </HTTPSamplerProxy>
-              <hashTree>
-                <BeanShellPostProcessor guiclass="TestBeanGUI" testclass="BeanShellPostProcessor" testname="BeanShell PostProcessor" enabled="true">
-                  <boolProp name="resetInterpreter">false</boolProp>
-                  <stringProp name="parameters"></stringProp>
-                  <stringProp name="filename"></stringProp>
-                  <stringProp name="script">import com.zimbra.zimbrasync.wbxml.BinaryParser;
+              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="Sync" enabled="true">
+                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_AIRSYNC,BinarySerializer.AIRSYNC_SYNC);
+bs.openTag(BinarySerializer.NAMESPACE_AIRSYNC,BinarySerializer.AIRSYNC_COLLECTIONS);
+bs.openTag(BinarySerializer.NAMESPACE_AIRSYNC,BinarySerializer.AIRSYNC_COLLECTION);
+bs.textElement(BinarySerializer.NAMESPACE_AIRSYNC,BinarySerializer.AIRSYNC_SYNCKEY,vars.get(&quot;SYNCSYNCKEY&quot;));
+bs.integerElement(BinarySerializer.NAMESPACE_AIRSYNC,BinarySerializer.AIRSYNC_COLLECTIONID,2);
+bs.closeTag();
+bs.closeTag();
+bs.closeTag();
+
+//Add WBXML Body to request
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+//Disable SSL validation/verification
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+//Create http connection and send request
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
 String result=&quot;&quot;;
 try {
-  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(data),false);
-
+  BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
   while (bp.next() != null) {
     if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
       result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
@@ -804,15 +815,26 @@ try {
       result+=bp.getText(); 	
     }
   }
-} catch (e) {
-   log.info(&quot;Sync exception thrown: &quot;+e);
+} catch (IOException e) {
+  if (e.message.equals(&quot;Unexpected EOF&quot;)) {
+  	// ignore
+  } else {
+  	throw e;
+  }
 }
-prev.setResponseData(result);</stringProp>
-                </BeanShellPostProcessor>
-                <hashTree/>
+SampleResult.setResponseData(result);
+
+} catch (Exception e) {
+	log.error(&quot;Sync:&quot;+e.toString());
+}</stringProp>
+                <stringProp name="BeanShellSampler.filename"></stringProp>
+                <stringProp name="BeanShellSampler.parameters"></stringProp>
+                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+              </BeanShellSampler>
+              <hashTree>
                 <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="XPath Extractor" enabled="true">
-                  <stringProp name="XPathExtractor.default">${SYNCKEY}</stringProp>
-                  <stringProp name="XPathExtractor.refname">SYNCKEY</stringProp>
+                  <stringProp name="XPathExtractor.default">${SYNCSYNCKEY}</stringProp>
+                  <stringProp name="XPathExtractor.refname">SYNCSYNCKEY</stringProp>
                   <stringProp name="XPathExtractor.xpathQuery">//SyncKey</stringProp>
                   <boolProp name="XPathExtractor.validate">false</boolProp>
                   <boolProp name="XPathExtractor.tolerant">false</boolProp>

--- a/tests/generic/eas/eas.jmx
+++ b/tests/generic/eas/eas.jmx
@@ -159,21 +159,6 @@
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="EAS Settings" enabled="true">
-          <collectionProp name="Arguments.arguments">
-            <elementProp name="FOLDERSYNCKEY" elementType="Argument">
-              <stringProp name="Argument.name">FOLDERSYNCKEY</stringProp>
-              <stringProp name="Argument.value">0</stringProp>
-              <stringProp name="Argument.metadata">=</stringProp>
-            </elementProp>
-            <elementProp name="SYNCSYNCKEY" elementType="Argument">
-              <stringProp name="Argument.name">SYNCSYNCKEY</stringProp>
-              <stringProp name="Argument.value">0</stringProp>
-              <stringProp name="Argument.metadata">=</stringProp>
-            </elementProp>
-          </collectionProp>
-        </Arguments>
-        <hashTree/>
         <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="START" enabled="true">
           <stringProp name="BeanShellSampler.query">import com.zimbra.jmeter.Zimbra;
 import com.zimbra.jmeter.Command;
@@ -205,7 +190,10 @@ if (commands.size() &gt; 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;true&quot;);
 } else {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
-}</stringProp>
+}
+// initialize sync keys
+vars.put(&quot;FOLDERSYNCKEY&quot;,&quot;0&quot;);
+vars.put(&quot;SYNCSYNCKEY&quot;,&quot;0&quot;);</stringProp>
           <stringProp name="BeanShellSampler.filename"></stringProp>
           <stringProp name="BeanShellSampler.parameters"></stringProp>
           <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
@@ -283,7 +271,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -392,7 +380,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -490,7 +478,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -587,7 +575,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -688,7 +676,7 @@ String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 hp.setHeader(&quot;Content-Type&quot;,&quot;message/rfc822&quot;);
 
 HttpEntity entity = new StringEntity(message);
@@ -752,6 +740,7 @@ import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.util.EntityUtils;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringEscapeUtils;
 import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpHeaders;
 import com.zimbra.zimbrasync.wbxml.BinarySerializer;
@@ -767,7 +756,7 @@ byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,&quot;12.1&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -806,13 +795,13 @@ try {
     if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
       result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
     } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;;
     } else if (bp.getEventType() == BinaryParser.START_TAG) {
-      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
     } else if (bp.getEventType() == BinaryParser.END_TAG) {
-      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;;
     } else if (bp.getEventType() == BinaryParser.TEXT) {
-      result+=bp.getText(); 	
+      result+=StringEscapeUtils.escapeXml(bp.getText());
     }
   }
 } catch (IOException e) {

--- a/tests/generic/eas/eas.jmx
+++ b/tests/generic/eas/eas.jmx
@@ -801,7 +801,10 @@ try {
     } else if (bp.getEventType() == BinaryParser.END_TAG) {
       result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;;
     } else if (bp.getEventType() == BinaryParser.TEXT) {
-      result+=StringEscapeUtils.escapeXml(bp.getText());
+    	 // ugly quick fix to resolve invalid XML characters
+    	 String text = bp.getText();
+      text=text.replaceAll(&quot;\\p{Cntrl}&quot;,&quot;&quot;);
+      result+=StringEscapeUtils.escapeXml(text);
     }
   }
 } catch (IOException e) {

--- a/tests/generic/eas/eas.jmx
+++ b/tests/generic/eas/eas.jmx
@@ -266,12 +266,12 @@ try {
 //Setup HTTP Request
 HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
                            &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -375,12 +375,12 @@ try {
 //Setup HTTP Request
 HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
                            &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -473,12 +473,12 @@ try {
 //Setup HTTP Request
 HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
                            &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -570,12 +570,12 @@ try {
 //Setup HTTP Request
 HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
                            &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -584,7 +584,9 @@ bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_SEARCH);
 bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_STORE);
 bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_NAME,&quot;Mailbox&quot;);
 bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_QUERY);
+bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_AND);
 bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_FREETEXT,&quot;test&quot;);
+bs.closeTag();
 bs.closeTag();
 bs.openTag(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_OPTIONS);
 bs.textElement(BinarySerializer.NAMESPACE_SEARCH,BinarySerializer.SEARCH_RANGE,&quot;0-9&quot;);
@@ -643,8 +645,12 @@ SampleResult.setResponseData(result);
                 <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
               </BeanShellSampler>
               <hashTree/>
-              <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="SendMail" enabled="true">
-                <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+              <SwitchController guiclass="SwitchControllerGui" testclass="SwitchController" testname="SendMail" enabled="true">
+                <stringProp name="SwitchController.value">${__P(EAS.version)}</stringProp>
+              </SwitchController>
+              <hashTree>
+                <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="default" enabled="true">
+                  <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.HttpResponse;
@@ -660,24 +666,24 @@ import org.apache.http.HttpHeaders;
 import com.zimbra.zimbrasync.wbxml.BinarySerializer;
 import com.zimbra.zimbrasync.wbxml.BinaryParser;
 
-String message = &quot;From: &lt;user1@zimbra07.loadtest.synacor.com&gt;\n&quot;;
-message += &quot;To: &lt;user1@zimbra07.loadtest.synacor.com&gt;\n&quot;;
+String message = &quot;From: &lt;&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;&gt;\n&quot;;
+message += &quot;To: &lt;&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;&gt;\n&quot;;
 message += &quot;Subject: From Active Sync\n&quot;;
 message += &quot;MIME-Version: 1.0\n&quot;;
 message += &quot;Content-Type:  text/plain; charset=utf-8\n&quot;;
 message += &quot;Content-Transfer-Encoding: 7bit\n\n&quot;;
-message += &quot;This is the message.\n&quot;;
+message += &quot;This is the test message.\n&quot;;
 
 try {
 //Setup HTTP Request
 HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
                            &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
 hp.setHeader(&quot;Content-Type&quot;,&quot;message/rfc822&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
 
 HttpEntity entity = new StringEntity(message);
 hp.setEntity(entity);
@@ -723,11 +729,198 @@ if (hr.getEntity().getContentLength() &gt; 0) {
 } catch (Exception e) {
 	log.error(&quot;SendMail exception: &quot;+e.toString());
 }</stringProp>
-                <stringProp name="BeanShellSampler.filename"></stringProp>
-                <stringProp name="BeanShellSampler.parameters"></stringProp>
-                <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
-              </BeanShellSampler>
-              <hashTree/>
+                  <stringProp name="BeanShellSampler.filename"></stringProp>
+                  <stringProp name="BeanShellSampler.parameters"></stringProp>
+                  <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+                </BeanShellSampler>
+                <hashTree/>
+                <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="14.0" enabled="true">
+                  <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+String message = &quot;From: &lt;&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;&gt;\n&quot;;
+message += &quot;To: &lt;&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;&gt;\n&quot;;
+message += &quot;Subject: From Active Sync\n&quot;;
+message += &quot;MIME-Version: 1.0\n&quot;;
+message += &quot;Content-Type:  text/plain; charset=utf-8\n&quot;;
+message += &quot;Content-Transfer-Encoding: 7bit\n\n&quot;;
+message += &quot;This is the test message.\n&quot;;
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_SENDMAIL);
+bs.textElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_CLIENTID,UUID.randomUUID().toString());
+bs.opaqueElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_MIME,message);
+bs.closeTag();
+
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
+if (hr.getEntity().getContentLength() &gt; 0) {
+  String result=&quot;&quot;;
+  try {
+    BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+    while (bp.next() != null) {
+      if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+        result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+      } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+        result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.START_TAG) {
+        result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.END_TAG) {
+        result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.TEXT) {
+        result+=bp.getText(); 	
+      }
+    }
+  } catch (Exception e) {
+    if (e.getMessage().equals(&quot;Unexpected EOF&quot;)) {
+      // ignore
+    } else {
+      throw e;
+    }
+  }
+  SampleResult.setResponseData(result);
+}
+} catch (Exception e) {
+	log.error(&quot;SendMail exception: &quot;+e.toString());
+}</stringProp>
+                  <stringProp name="BeanShellSampler.filename"></stringProp>
+                  <stringProp name="BeanShellSampler.parameters"></stringProp>
+                  <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+                </BeanShellSampler>
+                <hashTree/>
+                <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="14.1" enabled="true">
+                  <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.util.EntityUtils;
+import org.apache.commons.codec.binary.Base64;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHeaders;
+import com.zimbra.zimbrasync.wbxml.BinarySerializer;
+import com.zimbra.zimbrasync.wbxml.BinaryParser;
+
+String message = &quot;From: &lt;&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;&gt;\n&quot;;
+message += &quot;To: &lt;&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;&gt;\n&quot;;
+message += &quot;Subject: From Active Sync\n&quot;;
+message += &quot;MIME-Version: 1.0\n&quot;;
+message += &quot;Content-Type:  text/plain; charset=utf-8\n&quot;;
+message += &quot;Content-Transfer-Encoding: 7bit\n\n&quot;;
+message += &quot;This is the test message.\n&quot;;
+
+try {
+//Setup HTTP Request
+HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
+                           &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
+String authHeader = &quot;Basic &quot;+new String(encodedAuth);
+hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
+hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
+
+//Generate WBXML Request Body
+ByteArrayOutputStream bao = new ByteArrayOutputStream();
+BinarySerializer bs = new BinarySerializer(bao,false);
+bs.openTag(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_SENDMAIL);
+bs.textElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_CLIENTID,UUID.randomUUID().toString());
+bs.opaqueElement(BinarySerializer.NAMESPACE_COMPOSEMAIL,BinarySerializer.COMPOSEMAIL_MIME,message);
+bs.closeTag();
+
+HttpEntity entity = new ByteArrayEntity(bao.toByteArray());
+hp.setEntity(entity);
+
+SSLContextBuilder builder = new SSLContextBuilder();
+builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build(),SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+
+CloseableHttpClient dhc = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+HttpResponse hr = dhc.execute(hp);
+
+//Process reponse for reporting results in jmeter
+ResponseCode = hr.getStatusLine().getStatusCode();
+ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//Convert WBXML to readable form for jmeter
+if (hr.getEntity().getContentLength() &gt; 0) {
+  String result=&quot;&quot;;
+  try {
+    BinaryParser bp = new BinaryParser(new ByteArrayInputStream(EntityUtils.toByteArray(hr.getEntity())),false);
+    while (bp.next() != null) {
+      if (bp.getEventType() == BinaryParser.START_DOCUMENT) {
+        result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;;
+      } else if (bp.getEventType() == BinaryParser.END_DOCUMENT) {
+        result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.START_TAG) {
+        result+=&quot;&lt;&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.END_TAG) {
+        result+=&quot;&lt;/&quot;+bp.getName()+&quot;&gt;&quot;; 	
+      } else if (bp.getEventType() == BinaryParser.TEXT) {
+        result+=bp.getText(); 	
+      }
+    }
+  } catch (Exception e) {
+    if (e.getMessage().equals(&quot;Unexpected EOF&quot;)) {
+      // ignore
+    } else {
+      throw e;
+    }
+  }
+  SampleResult.setResponseData(result);
+}
+} catch (Exception e) {
+	log.error(&quot;SendMail exception: &quot;+e.toString());
+}</stringProp>
+                  <stringProp name="BeanShellSampler.filename"></stringProp>
+                  <stringProp name="BeanShellSampler.parameters"></stringProp>
+                  <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
+                </BeanShellSampler>
+                <hashTree/>
+              </hashTree>
               <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="Sync" enabled="true">
                 <stringProp name="BeanShellSampler.query">import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -746,17 +939,18 @@ import org.apache.http.HttpHeaders;
 import com.zimbra.zimbrasync.wbxml.BinarySerializer;
 import com.zimbra.zimbrasync.wbxml.BinaryParser;
 
+import org.apache.http.Header;
 
 try {
 //Setup HTTP Request
 HttpPost hp = new HttpPost(vars.get(&quot;URL&quot;)+&quot;?Cmd=&quot;+vars.get(&quot;COMMAND&quot;)+&quot;&amp;User=&quot;+vars.get(&quot;USER&quot;)+
                            &quot;&amp;DeviceId=testing&amp;DeviceType=jmeter&quot;);
-String auth = vars.get(&quot;USER&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
+String auth = vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;:&quot;+vars.get(&quot;PASS&quot;);
 byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.ISO_8859_1));
 String authHeader = &quot;Basic &quot;+new String(encodedAuth);
 hp.setHeader(HttpHeaders.AUTHORIZATION,authHeader);
 hp.setHeader(&quot;Content-Type&quot;,&quot;application/vnd.ms-sync.wbxml&quot;);
-hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;PROFILE.EAS.version&quot;));
+hp.setHeader(&quot;MS-ASProtocolVersion&quot;,props.get(&quot;EAS.version&quot;));
 
 //Generate WBXML Request Body
 ByteArrayOutputStream bao = new ByteArrayOutputStream();
@@ -786,6 +980,11 @@ HttpResponse hr = dhc.execute(hp);
 //Process reponse for reporting results in jmeter
 ResponseCode = hr.getStatusLine().getStatusCode();
 ResponseMessage = hr.getStatusLine().getReasonPhrase();
+
+//View headers for debug
+//for (Header h : hr.getAllHeaders()) {
+//  log.info(&quot;Header: &quot;+h.getName()+&quot;=&quot;+h.getValue());
+//}
 
 //Convert WBXML to readable form for jmeter
 String result=&quot;&quot;;

--- a/tests/generic/eas/eas.md
+++ b/tests/generic/eas/eas.md
@@ -1,3 +1,15 @@
+# Version
+
+## Zimbra 8.7.9_GA_1794
+
+MS_Server-ActiveSync = 8.1
+MS_ASProtocolVersions = 2.0,2.1,2.5,12.0,12.1
+
+## Zimbra 8.8.8_GA_2009
+
+MS_Server-ActiveSync = 15.0
+MS_ASProtocolVersions = 2.5,12.0,12.1,14.0,14.1
+
 # EAS Commands
 
 | Command      | Arguments | Requires               | Captures                | Note |

--- a/tests/generic/eas/eas.md
+++ b/tests/generic/eas/eas.md
@@ -1,9 +1,10 @@
 # EAS Commands
 
-| Command      | Arguments | Requires         | Captures    | Note |
-| ------------ | --------- | ---------------- | ----------- | ---- |
-| SendMail     |           |                  |             |      |
-| Sync         |           |                  |             |      |
-| FolderCreate |           |                  |             |      |
-| FolderDelete |           |                  |             |      |
-| Search       |           |                  |             |      |
+| Command      | Arguments | Requires               | Captures                | Note |
+| ------------ | --------- | ---------------------- | ----------------------- | ---- |
+| FolderCreate |           | FOLDERSYNCKEY          | FOLDERSYNCKEY, FOLDERID |      |
+| FolderDelete |           | FOLDERSYNCKEY,FOLDERID | FOLDERSYNCKEY           |      |
+| FolderSync   |           | FOLDERSYNCKEY          | FOLDERSYNCKEY           |      |
+| Search       |           |                        |                         |      |
+| SendMail     |           |                        |                         |      |
+| Sync         |           | SYNCSYNCKEY            | SYNCSYNCKEY             |      |

--- a/tests/generic/eas/eas.md
+++ b/tests/generic/eas/eas.md
@@ -1,0 +1,9 @@
+# EAS Commands
+
+| Command      | Arguments | Requires         | Captures    | Note |
+| ------------ | --------- | ---------------- | ----------- | ---- |
+| SendMail     |           |                  |             |      |
+| Sync         |           |                  |             |      |
+| FolderCreate |           |                  |             |      |
+| FolderDelete |           |                  |             |      |
+| Search       |           |                  |             |      |

--- a/tests/generic/eas/env.prop
+++ b/tests/generic/eas/env.prop
@@ -1,6 +1,7 @@
 HTTP.server=host.domain.com
 HTTP.port=443
 HTTP.protocol=https
+EAS.version=12.1
 ACCOUNTS.csv=config/users.csv
 REQUEST.log=requests.log
 user.classpath=src/build/jar/zjmeter.jar:src/build/jar/zm-sync-common.jar

--- a/tests/generic/eas/env.prop
+++ b/tests/generic/eas/env.prop
@@ -3,4 +3,4 @@ HTTP.port=443
 HTTP.protocol=https
 ACCOUNTS.csv=config/users.csv
 REQUEST.log=requests.log
-user.classpath=src/build/jar/zjmeter.jar
+user.classpath=src/build/jar/zjmeter.jar:src/build/jar/zm-sync-common.jar

--- a/tests/generic/eas/env.prop
+++ b/tests/generic/eas/env.prop
@@ -1,0 +1,6 @@
+HTTP.server=host.domain.com
+HTTP.port=443
+HTTP.protocol=https
+ACCOUNTS.csv=config/users.csv
+REQUEST.log=requests.log
+user.classpath=src/build/jar/zjmeter.jar

--- a/tests/generic/eas/load.prop
+++ b/tests/generic/eas/load.prop
@@ -1,0 +1,4 @@
+LOAD.EAS.users=1
+LOAD.EAS.userduration=1
+LOAD.EAS.rampup=0
+LOAD.EAS.loopcount=1

--- a/tests/generic/eas/profiles/basic.prop
+++ b/tests/generic/eas/profiles/basic.prop
@@ -1,7 +1,9 @@
+PROFILE.EAS.version=12.1
 PROFILE.EAS.type=sequence
 PROFILE.EAS.sequence.1=FolderSync
 PROFILE.EAS.sequence.2=FolderCreate
 PROFILE.EAS.sequence.3=FolderDelete
 PROFILE.EAS.sequence.4=SendMail
 PROFILE.EAS.sequence.5=Sync
-PROFILE.EAS.sequence.6=Search
+PROFILE.EAS.sequence.6=Sync
+PROFILE.EAS.sequence.7=Search

--- a/tests/generic/eas/profiles/basic.prop
+++ b/tests/generic/eas/profiles/basic.prop
@@ -1,0 +1,7 @@
+PROFILE.EAS.type=sequence
+PROFILE.EAS.sequence.1=FolderSync
+PROFILE.EAS.sequence.2=FolderCreate
+PROFILE.EAS.sequence.3=FolderDelete
+PROFILE.EAS.sequence.4=SendMail
+PROFILE.EAS.sequence.5=Sync
+PROFILE.EAS.sequence.6=Search

--- a/tests/generic/eas/profiles/basic.prop
+++ b/tests/generic/eas/profiles/basic.prop
@@ -1,9 +1,9 @@
-PROFILE.EAS.version=12.1
 PROFILE.EAS.type=sequence
 PROFILE.EAS.sequence.1=FolderSync
 PROFILE.EAS.sequence.2=FolderCreate
 PROFILE.EAS.sequence.3=FolderDelete
-PROFILE.EAS.sequence.4=SendMail
-PROFILE.EAS.sequence.5=Sync
+PROFILE.EAS.sequence.4=FolderSync
+PROFILE.EAS.sequence.5=SendMail
 PROFILE.EAS.sequence.6=Sync
-PROFILE.EAS.sequence.7=Search
+PROFILE.EAS.sequence.7=Sync
+PROFILE.EAS.sequence.8=Search


### PR DESCRIPTION
This test depends on zm-sync-common.jar and assumes you place it in src/build/jar for testing.

Because of the above the test is not included on default if you try to run all the tests from ant.

The ant target does exist as generic-eas and you can be run directly as "ant generic-eas" if the above jar file is not installed it will generate an error with a message indicating that you need to add the jar file.