### PR TITLE
ZCS-5015 caldav/cardav using the wrong url for loop tests.

### DIFF
--- a/tests/generic/caldav/caldav.jmx
+++ b/tests/generic/caldav/caldav.jmx
@@ -180,17 +180,6 @@ vars.putObject(&quot;CalDAV&quot;,cd);</stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="CalDAV Variables" enabled="true">
-          <collectionProp name="Arguments.arguments">
-            <elementProp name="APPTUUID" elementType="Argument">
-              <stringProp name="Argument.name">APPTUUID</stringProp>
-              <stringProp name="Argument.value">${__UUID()}</stringProp>
-              <stringProp name="Argument.desc">ID to use with put</stringProp>
-              <stringProp name="Argument.metadata">=</stringProp>
-            </elementProp>
-          </collectionProp>
-        </Arguments>
-        <hashTree/>
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="CalDAV HTTP Config" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
@@ -201,7 +190,7 @@ vars.putObject(&quot;CalDAV&quot;,cd);</stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol">${__P(HTTP.protocol)}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/dav/${USER}/Calendar</stringProp>
+          <stringProp name="HTTPSampler.path">/dav/${USER}@${__P(HTTP.domain)}/Calendar</stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
           <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
         </ConfigTestElement>
@@ -238,7 +227,10 @@ if (commands.size() &gt; 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;true&quot;);
 } else {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
-}</stringProp>
+}
+// initialize APPTUUID and APPTURL
+vars.put(&quot;APPTUUID&quot;,UUID.randomUUID().toString());
+vars.put(&quot;APPTURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;/Calendar/&quot;+vars.get(&quot;APPTUUID&quot;)+&quot;.ics&quot;);</stringProp>
           <stringProp name="BeanShellSampler.filename"></stringProp>
           <stringProp name="BeanShellSampler.parameters"></stringProp>
           <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
@@ -265,9 +257,6 @@ if (commands.size() &gt; 0) {
   	}
   }
   //log.info(vars.get(&quot;COMMAND&quot;));
-}
-if (vars.get(&quot;APPTURL&quot;) == null || vars.get(&quot;APPTURL&quot;).equals(&quot;&quot;)) {
-  vars.put(&quot;APPTURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;/Calendar/&quot;+vars.get(&quot;APPTUUID&quot;)+&quot;.ics&quot;);
 }
 if (commands.size() == 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);

--- a/tests/generic/caldav/caldav.jmx
+++ b/tests/generic/caldav/caldav.jmx
@@ -419,6 +419,15 @@ vars.put(&quot;APPTBODY&quot;,m);</stringProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
               <hashTree>
+                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                  <collectionProp name="HeaderManager.headers">
+                    <elementProp name="" elementType="Header">
+                      <stringProp name="Header.name">Content-Type</stringProp>
+                      <stringProp name="Header.value">text/calendar</stringProp>
+                    </elementProp>
+                  </collectionProp>
+                </HeaderManager>
+                <hashTree/>
                 <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Modify" enabled="true">
                   <boolProp name="resetInterpreter">false</boolProp>
                   <stringProp name="parameters"></stringProp>

--- a/tests/generic/carddav/carddav.jmx
+++ b/tests/generic/carddav/carddav.jmx
@@ -180,17 +180,6 @@ vars.putObject(&quot;CardDAV&quot;,cd);</stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="CardDAV Variables" enabled="true">
-          <collectionProp name="Arguments.arguments">
-            <elementProp name="CARDUUID" elementType="Argument">
-              <stringProp name="Argument.name">CARDUUID</stringProp>
-              <stringProp name="Argument.value">${__UUID()}</stringProp>
-              <stringProp name="Argument.desc">ID to use with put</stringProp>
-              <stringProp name="Argument.metadata">=</stringProp>
-            </elementProp>
-          </collectionProp>
-        </Arguments>
-        <hashTree/>
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="CardDAV HTTP Config" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
@@ -201,7 +190,7 @@ vars.putObject(&quot;CardDAV&quot;,cd);</stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol">${__P(HTTP.protocol)}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/dav/${USER}/Contacts</stringProp>
+          <stringProp name="HTTPSampler.path">/dav/${USER}@${__P(HTTP.domain)}/Contacts</stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
           <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
         </ConfigTestElement>
@@ -238,7 +227,10 @@ if (commands.size() &gt; 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;true&quot;);
 } else {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
-}</stringProp>
+}
+// initialize CARDUUID and CARDURL
+vars.put(&quot;CARDUUID&quot;,UUID.randomUUID().toString());
+vars.put(&quot;CARDURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;/Contacts/&quot;+vars.get(&quot;CARDUUID&quot;)+&quot;.vcf&quot;);</stringProp>
           <stringProp name="BeanShellSampler.filename"></stringProp>
           <stringProp name="BeanShellSampler.parameters"></stringProp>
           <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
@@ -265,9 +257,6 @@ if (commands.size() &gt; 0) {
   	}
   }
   //log.info(vars.get(&quot;COMMAND&quot;));
-}
-if (vars.get(&quot;CARDURL&quot;) == null || vars.get(&quot;CARDURL&quot;).equals(&quot;&quot;)) {
-  vars.put(&quot;CARDURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;/Contacts/&quot;+vars.get(&quot;CARDUUID&quot;)+&quot;.vcf&quot;);
 }
 if (commands.size() == 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
@@ -426,6 +415,15 @@ vars.put(&quot;APPTBODY&quot;,m);
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
               <hashTree>
+                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                  <collectionProp name="HeaderManager.headers">
+                    <elementProp name="" elementType="Header">
+                      <stringProp name="Header.name">Content-Type</stringProp>
+                      <stringProp name="Header.value">text/vcard</stringProp>
+                    </elementProp>
+                  </collectionProp>
+                </HeaderManager>
+                <hashTree/>
                 <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Modify" enabled="true">
                   <boolProp name="resetInterpreter">false</boolProp>
                   <stringProp name="parameters"></stringProp>

--- a/tests/generic/mix/mix.jmx
+++ b/tests/generic/mix/mix.jmx
@@ -3786,17 +3786,6 @@ vars.putObject(&quot;CalDAV&quot;,cd);</stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="CalDAV Variables" enabled="true">
-          <collectionProp name="Arguments.arguments">
-            <elementProp name="APPTUUID" elementType="Argument">
-              <stringProp name="Argument.name">APPTUUID</stringProp>
-              <stringProp name="Argument.value">${__UUID()}</stringProp>
-              <stringProp name="Argument.desc">ID to use with put</stringProp>
-              <stringProp name="Argument.metadata">=</stringProp>
-            </elementProp>
-          </collectionProp>
-        </Arguments>
-        <hashTree/>
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="CalDAV HTTP Config" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
@@ -3807,7 +3796,7 @@ vars.putObject(&quot;CalDAV&quot;,cd);</stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol">${__P(HTTP.protocol)}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/dav/${USER}/Calendar</stringProp>
+          <stringProp name="HTTPSampler.path">/dav/${USER}@${__P(HTTP.domain)}/Calendar</stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
           <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
         </ConfigTestElement>
@@ -3844,7 +3833,10 @@ if (commands.size() &gt; 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;true&quot;);
 } else {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
-}</stringProp>
+}
+// initialize APPTUUID and APPTURL
+vars.put(&quot;APPTUUID&quot;,UUID.randomUUID().toString());
+vars.put(&quot;APPTURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;/Calendar/&quot;+vars.get(&quot;APPTUUID&quot;)+&quot;.ics&quot;);</stringProp>
           <stringProp name="BeanShellSampler.filename"></stringProp>
           <stringProp name="BeanShellSampler.parameters"></stringProp>
           <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
@@ -3871,9 +3863,6 @@ if (commands.size() &gt; 0) {
   	}
   }
   //log.info(vars.get(&quot;COMMAND&quot;));
-}
-if (vars.get(&quot;APPTURL&quot;) == null || vars.get(&quot;APPTURL&quot;).equals(&quot;&quot;)) {
-  vars.put(&quot;APPTURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;/Calendar/&quot;+vars.get(&quot;APPTUUID&quot;)+&quot;.ics&quot;);
 }
 if (commands.size() == 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
@@ -4025,6 +4014,15 @@ vars.put(&quot;APPTBODY&quot;,m);</stringProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
               <hashTree>
+                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                  <collectionProp name="HeaderManager.headers">
+                    <elementProp name="" elementType="Header">
+                      <stringProp name="Header.name">Content-Type</stringProp>
+                      <stringProp name="Header.value">text/calendar</stringProp>
+                    </elementProp>
+                  </collectionProp>
+                </HeaderManager>
+                <hashTree/>
                 <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Modify" enabled="true">
                   <boolProp name="resetInterpreter">false</boolProp>
                   <stringProp name="parameters"></stringProp>
@@ -4083,17 +4081,6 @@ vars.putObject(&quot;CardDAV&quot;,cd);</stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <Arguments guiclass="ArgumentsPanel" testclass="Arguments" testname="CardDAV Variables" enabled="true">
-          <collectionProp name="Arguments.arguments">
-            <elementProp name="CARDUUID" elementType="Argument">
-              <stringProp name="Argument.name">CARDUUID</stringProp>
-              <stringProp name="Argument.value">${__UUID()}</stringProp>
-              <stringProp name="Argument.desc">ID to use with put</stringProp>
-              <stringProp name="Argument.metadata">=</stringProp>
-            </elementProp>
-          </collectionProp>
-        </Arguments>
-        <hashTree/>
         <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="CardDAV HTTP Config" enabled="true">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
@@ -4104,7 +4091,7 @@ vars.putObject(&quot;CardDAV&quot;,cd);</stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol">${__P(HTTP.protocol)}</stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/dav/${USER}/Contacts</stringProp>
+          <stringProp name="HTTPSampler.path">/dav/${USER}@${__P(HTTP.domain)}/Contacts</stringProp>
           <stringProp name="HTTPSampler.implementation">HttpClient4</stringProp>
           <stringProp name="HTTPSampler.concurrentPool">6</stringProp>
         </ConfigTestElement>
@@ -4141,7 +4128,10 @@ if (commands.size() &gt; 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;true&quot;);
 } else {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
-}</stringProp>
+}
+// initialize CARDUUID and CARDURL
+vars.put(&quot;CARDUUID&quot;,UUID.randomUUID().toString());
+vars.put(&quot;CARDURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;@&quot;+props.get(&quot;HTTP.domain&quot;)+&quot;/Contacts/&quot;+vars.get(&quot;CARDUUID&quot;)+&quot;.vcf&quot;);</stringProp>
           <stringProp name="BeanShellSampler.filename"></stringProp>
           <stringProp name="BeanShellSampler.parameters"></stringProp>
           <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
@@ -4168,9 +4158,6 @@ if (commands.size() &gt; 0) {
   	}
   }
   //log.info(vars.get(&quot;COMMAND&quot;));
-}
-if (vars.get(&quot;CARDURL&quot;) == null || vars.get(&quot;CARDURL&quot;).equals(&quot;&quot;)) {
-  vars.put(&quot;CARDURL&quot;,&quot;/dav/&quot;+vars.get(&quot;USER&quot;)+&quot;/Contacts/&quot;+vars.get(&quot;CARDUUID&quot;)+&quot;.vcf&quot;);
 }
 if (commands.size() == 0) {
   vars.put(&quot;CONTINUE&quot;,&quot;false&quot;);
@@ -4329,6 +4316,15 @@ vars.put(&quot;APPTBODY&quot;,m);
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
               <hashTree>
+                <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+                  <collectionProp name="HeaderManager.headers">
+                    <elementProp name="" elementType="Header">
+                      <stringProp name="Header.name">Content-Type</stringProp>
+                      <stringProp name="Header.value">text/vcard</stringProp>
+                    </elementProp>
+                  </collectionProp>
+                </HeaderManager>
+                <hashTree/>
                 <BeanShellPreProcessor guiclass="TestBeanGUI" testclass="BeanShellPreProcessor" testname="Modify" enabled="true">
                   <boolProp name="resetInterpreter">false</boolProp>
                   <stringProp name="parameters"></stringProp>


### PR DESCRIPTION
This addresses errors identified in e-mail:

[aname=pn1@zmc.com;ip=10.0.0.19;port=54392;ua=Apache-HttpClient/4.5.2 (Java/1.8.0_171);] dav - can't get mail item resource for user='admin' path='/Calendar'
com.zimbra.common.service.ServiceException: permission denied: you do not have sufficient permissions