### PR TITLE
ZCS-5851: Added MsgActionRequest type(read) in basic.prop for zsoap and mix perf tesing

### DIFF
--- a/tests/generic/mix/profiles/basic.prop
+++ b/tests/generic/mix/profiles/basic.prop
@@ -47,7 +47,7 @@ PROFILE.ZSOAP.sequence.5=SendMsgRequest
 PROFILE.ZSOAP.sequence.6=SearchRequest(SEARCHTYPE=message,SEARCH=*)
 PROFILE.ZSOAP.sequence.7=GetMsgRequest
 PROFILE.ZSOAP.sequence.8=SearchRequest(SEARCHTYPE=conversation,SEARCH=*)
-PROFILE.ZSOAP.sequence.9=MsgActionRequest
+PROFILE.ZSOAP.sequence.9=MsgActionRequest(MSGACTIONTYPE=read)
 PROFILE.ZSOAP.sequence.10=CreateAppointmentRequest
 PROFILE.ZSOAP.sequence.11=SearchRequest(SEARCHTYPE=appointment,SEARCH=*)
 PROFILE.ZSOAP.sequence.12=CreateTagRequest

--- a/tests/generic/zsoap/profiles/basic.prop
+++ b/tests/generic/zsoap/profiles/basic.prop
@@ -7,7 +7,7 @@ PROFILE.ZSOAP.sequence.5=SendMsgRequest
 PROFILE.ZSOAP.sequence.6=SearchRequest(SEARCHTYPE=message,SEARCH=*)
 PROFILE.ZSOAP.sequence.7=GetMsgRequest
 PROFILE.ZSOAP.sequence.8=SearchRequest(SEARCHTYPE=conversation,SEARCH=*)
-PROFILE.ZSOAP.sequence.9=MsgActionRequest
+PROFILE.ZSOAP.sequence.9=MsgActionRequest(MSGACTIONTYPE=read)
 PROFILE.ZSOAP.sequence.10=SearchRequest(SEARCHTYPE=appointment,SEARCH=*)
 PROFILE.ZSOAP.sequence.11=CreateAppointmentRequest
 PROFILE.ZSOAP.sequence.12=CreateTagRequest


### PR DESCRIPTION
Added MsgActionRequest type(read) in basic.prop for zsoap and mix perf tesing
In present property file no action type is mentioned due to which it sometimes delete the message instead of marking it as read and then tag message request fails.