### PR TITLE
ZCS-5914: Fix issues observed with zmc-perf harness run using test.prop on AWS cluster

### DIFF
--- a/tests/generic/zsoap/zsoap.jmx
+++ b/tests/generic/zsoap/zsoap.jmx
@@ -176,7 +176,7 @@ Zimbra soap = new Zimbra(props,&quot;ZSOAP&quot;);
 vars.putObject(&quot;ZSOAP&quot;,soap);
 
 String url = &quot;https://&quot;+props.get(&quot;HTTP.server&quot;);
-String admin = url+&quot;:7071/service/admin/soap&quot;;
+String admin = url+&quot;:&quot;+ props.get(&quot;HTTP.admin.port&quot;)+&quot;/service/admin/soap&quot;;
 vars.put(&quot;ADMIN&quot;,admin);
 if (!props.get(&quot;HTTP.port&quot;).equals(&quot;&quot;) ) {
   url = url + &quot;:&quot; + props.get(&quot;HTTP.port&quot;); 


### PR DESCRIPTION
Modified admin soap url to take port value from config file.
Tested changes with positve and negative scenarios.