### PR TITLE
ZCS-6038: Jmeter ZSoap test improvement

### DIFF
--- a/tests/generic/zsoap/profiles/test.prop
+++ b/tests/generic/zsoap/profiles/test.prop
@@ -27,8 +27,8 @@ PROFILE.ZSOAP.sequence.25=SearchRequest(SEARCHTYPE=conversation,SEARCH=*)
 PROFILE.ZSOAP.sequence.26=SearchConvRequest
 PROFILE.ZSOAP.sequence.27=GetConvRequest
 PROFILE.ZSOAP.sequence.28=ConvActionRequest
-PROFILE.ZSOAP.sequence.29=GetFolderRequest
-PROFILE.ZSOAP.sequence.30=FolderActionRequest
+PROFILE.ZSOAP.sequence.29=GetFolderRequest(PATH=inbox)
+PROFILE.ZSOAP.sequence.30=FolderActionRequest(FOLDERACTIONTYPE=read)
 PROFILE.ZSOAP.sequence.31=CreateContactRequest
 PROFILE.ZSOAP.sequence.32=GetContactsRequest
 PROFILE.ZSOAP.sequence.33=ContactActionRequest

--- a/tests/generic/zsoap/zsoap.jmx
+++ b/tests/generic/zsoap/zsoap.jmx
@@ -176,7 +176,7 @@ Zimbra soap = new Zimbra(props,&quot;ZSOAP&quot;);
 vars.putObject(&quot;ZSOAP&quot;,soap);
 
 String url = &quot;https://&quot;+props.get(&quot;HTTP.server&quot;);
-String admin = url+&quot;:7071/service/admin/soap&quot;;
+String admin = url+&quot;:&quot;+ props.get(&quot;HTTP.admin.port&quot;)+&quot;/service/admin/soap&quot;;
 vars.put(&quot;ADMIN&quot;,admin);
 if (!props.get(&quot;HTTP.port&quot;).equals(&quot;&quot;) ) {
   url = url + &quot;:&quot; + props.get(&quot;HTTP.port&quot;); 
@@ -269,7 +269,7 @@ if (commands.size() &gt; 0) {
   }
   if (c.getName().equals(&quot;GetFolderRequest&quot;)) {
     if (c.getArg(&quot;PATH&quot;) == null) {
-      vars.put(&quot;PATH&quot;,&quot;/inbox&quot;);
+      vars.put(&quot;PATH&quot;,&quot;inbox&quot;);
     }
   }
   if (c.getName().equals(&quot;TagActionRequest&quot;)) {
@@ -750,7 +750,18 @@ if (commands.size() == 0) {
                 <boolProp name="HTTPSampler.monitor">false</boolProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
-              <hashTree/>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="CONTACT" enabled="true">
+                  <stringProp name="XPathExtractor.default"></stringProp>
+                  <stringProp name="XPathExtractor.refname">CONTACT</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//cn/@id</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                  <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="CreateFolderRequest" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -790,7 +801,18 @@ if (commands.size() == 0) {
                 <boolProp name="HTTPSampler.monitor">false</boolProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
-              <hashTree/>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="FOLDER" enabled="true">
+                  <stringProp name="XPathExtractor.default"></stringProp>
+                  <stringProp name="XPathExtractor.refname">FOLDER</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//folder/@id | //search/@id</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                  <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="CreateSearchFolderRequest" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -830,7 +852,18 @@ if (commands.size() == 0) {
                 <boolProp name="HTTPSampler.monitor">false</boolProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
-              <hashTree/>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="FOLDER" enabled="true">
+                  <stringProp name="XPathExtractor.default"></stringProp>
+                  <stringProp name="XPathExtractor.refname">FOLDER</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//folder/@id | //search/@id</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                  <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="CreateTagRequest" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -870,7 +903,18 @@ if (commands.size() == 0) {
                 <boolProp name="HTTPSampler.monitor">false</boolProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
-              <hashTree/>
+              <hashTree>
+                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="TAG" enabled="true">
+                  <stringProp name="XPathExtractor.default"></stringProp>
+                  <stringProp name="XPathExtractor.refname">TAG</stringProp>
+                  <stringProp name="XPathExtractor.xpathQuery">//tag/@id</stringProp>
+                  <boolProp name="XPathExtractor.validate">false</boolProp>
+                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
+                  <boolProp name="XPathExtractor.namespace">false</boolProp>
+                  <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
+                </XPathExtractor>
+                <hashTree/>
+              </hashTree>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="CreateWaitSetRequest" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -1535,18 +1579,7 @@ if (commands.size() == 0) {
                 <boolProp name="HTTPSampler.monitor">false</boolProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
-              <hashTree>
-                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="CONTACT" enabled="true">
-                  <stringProp name="XPathExtractor.default"></stringProp>
-                  <stringProp name="XPathExtractor.refname">CONTACT</stringProp>
-                  <stringProp name="XPathExtractor.xpathQuery">//cn/@id</stringProp>
-                  <boolProp name="XPathExtractor.validate">false</boolProp>
-                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
-                  <boolProp name="XPathExtractor.namespace">false</boolProp>
-                  <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
-                </XPathExtractor>
-                <hashTree/>
-              </hashTree>
+              <hashTree/>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GetConvRequest" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -1681,7 +1714,7 @@ if (commands.size() == 0) {
   &lt;/soap:Header&gt;&#xd;
   &lt;soap:Body&gt;&#xd;
     &lt;GetDomainInfoRequest xmlns=&quot;urn:zimbraAdmin&quot;&gt;&#xd;
-      &lt;domain by=&quot;name&quot;&gt;zimbra07.loadtest.synacor.ocm&lt;/domain&gt;&#xd;
+      &lt;domain by=&quot;name&quot;&gt;${__P(HTTP.server)}&lt;/domain&gt;&#xd;
     &lt;/GetDomainInfoRequest&gt;&#xd;
    &lt;/soap:Body&gt;&#xd;
 &lt;/soap:Envelope&gt;</stringProp>
@@ -1797,18 +1830,7 @@ if (commands.size() == 0) {
                   <boolProp name="HTTPSampler.monitor">false</boolProp>
                   <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
                 </HTTPSamplerProxy>
-                <hashTree>
-                  <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="FOLDER" enabled="true">
-                    <stringProp name="XPathExtractor.default"></stringProp>
-                    <stringProp name="XPathExtractor.refname">FOLDER</stringProp>
-                    <stringProp name="XPathExtractor.xpathQuery">//folder/@id | //search/@id</stringProp>
-                    <boolProp name="XPathExtractor.validate">false</boolProp>
-                    <boolProp name="XPathExtractor.tolerant">false</boolProp>
-                    <boolProp name="XPathExtractor.namespace">false</boolProp>
-                    <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
-                  </XPathExtractor>
-                  <hashTree/>
-                </hashTree>
+                <hashTree/>
                 <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="SearchFolderRequest" enabled="true">
                   <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                   <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -1846,19 +1868,8 @@ if (commands.size() == 0) {
                   <boolProp name="HTTPSampler.monitor">false</boolProp>
                   <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
                 </HTTPSamplerProxy>
-                <hashTree>
-                  <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="FOLDER" enabled="true">
-                    <stringProp name="XPathExtractor.default"></stringProp>
-                    <stringProp name="XPathExtractor.refname">FOLDER</stringProp>
-                    <stringProp name="XPathExtractor.xpathQuery">//folder/@id | //search/@id</stringProp>
-                    <boolProp name="XPathExtractor.validate">false</boolProp>
-                    <boolProp name="XPathExtractor.tolerant">false</boolProp>
-                    <boolProp name="XPathExtractor.namespace">false</boolProp>
-                    <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
-                  </XPathExtractor>
-                  <hashTree/>
-                </hashTree>
-                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="default" enabled="true">
+                <hashTree/>
+                <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="inbox" enabled="true">
                   <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                   <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
                     <collectionProp name="Arguments.arguments">
@@ -1874,7 +1885,7 @@ if (commands.size() == 0) {
   &lt;/soap:Header&gt;&#xd;
   &lt;soap:Body&gt;&#xd;
     &lt;GetFolderRequest xmlns=&quot;urn:zimbraMail&quot;&gt;&#xd;
-      &lt;folder path=&quot;/&quot;/&gt;&#xd;
+      &lt;folder path=&quot;/inbox&quot;/&gt;&#xd;
     &lt;/GetFolderRequest&gt;&#xd;
    &lt;/soap:Body&gt;&#xd;
 &lt;/soap:Envelope&gt;</stringProp>
@@ -2293,18 +2304,7 @@ if (commands.size() == 0) {
                 <boolProp name="HTTPSampler.monitor">false</boolProp>
                 <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
               </HTTPSamplerProxy>
-              <hashTree>
-                <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="TAG" enabled="true">
-                  <stringProp name="XPathExtractor.default"></stringProp>
-                  <stringProp name="XPathExtractor.refname">TAG</stringProp>
-                  <stringProp name="XPathExtractor.xpathQuery">//tag/@id</stringProp>
-                  <boolProp name="XPathExtractor.validate">false</boolProp>
-                  <boolProp name="XPathExtractor.tolerant">false</boolProp>
-                  <boolProp name="XPathExtractor.namespace">false</boolProp>
-                  <stringProp name="XPathExtractor.matchNumber">-1</stringProp>
-                </XPathExtractor>
-                <hashTree/>
-              </hashTree>
+              <hashTree/>
               <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GetWhiteBlackListRequest" enabled="true">
                 <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
                 <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
@@ -2359,7 +2359,7 @@ if (commands.size() == 0) {
   &lt;/soap:Header&gt;&#xd;
   &lt;soap:Body&gt;&#xd;
     &lt;ModifyAccountRequest id=&quot;${ACCOUNTID}&quot; xmlns=&quot;urn:zimbraAdmin&quot;&gt;&#xd;
-      &lt;a n=&quot;zimbraPrefIMFlashTitle&quot;&gt;FALSE&lt;/a&gt;&#xd;
+      &lt;a n=&quot;zimbraPrefGalAutoCompleteEnabled&quot;&gt;TRUE&lt;/a&gt;&#xd;
     &lt;/ModifyAccountRequest&gt;&#xd;
   &lt;/soap:Body&gt;&#xd;
 &lt;/soap:Envelope&gt;</stringProp>


### PR DESCRIPTION
ZCS-6038: Jmeter ZSoap test improvement - Use Get request instead of Search for Zsoap testcases

Changes:
1) Modified admin URL to use admin port number from env.prop file.
2) Modified ModifyAccountRequest request to use new variable instead of zimbraPrefIMFlashTitle which was deprecated.
3) Correct query for GetDomainInfoRequest to use correct server name.
4) Changed Approach for tag, folder and contact requests to avoid unwanted failures due to "invalid request: empty/missing item ID".

New Approach:
1) Create tag/folder/contact retrive and store the ID returned from the response.
2) Use these ID for other Actions like read/modify/delete.