### PR TITLE
ZCS-6098: Add Search related test coverage

### DIFF
--- a/tests/generic/zsoap/profiles/test.prop
+++ b/tests/generic/zsoap/profiles/test.prop
@@ -71,8 +71,21 @@ PROFILE.ZSOAP.sequence.69=GetWhiteBlackListRequest
 PROFILE.ZSOAP.sequence.70=ModifyAccountRequest
 PROFILE.ZSOAP.sequence.71=RankingActionRequest
 PROFILE.ZSOAP.sequence.72=GetInfoRequest
-PROFILE.ZSOAP.sequence.73=SearchRequest(SEARCHTYPE=message,SEARCH="is:invite not from:${USER}")
+PROFILE.ZSOAP.sequence.73=SearchRequest(SEARCHTYPE=appointment,SEARCH="subject:Subject of meeting perf zsoap testing")
+PROFILE.ZSOAP.sequence.74=SearchRequest(SEARCHTYPE=message,SEARCH="in:inbox")
+PROFILE.ZSOAP.sequence.75=SearchRequest(SEARCHTYPE=message,SEARCH="is:read")
+PROFILE.ZSOAP.sequence.76=SearchRequest(SEARCHTYPE=message,SEARCH="subject:Hello World larger:50b")
+PROFILE.ZSOAP.sequence.77=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER}")
+PROFILE.ZSOAP.sequence.78=SearchRequest(SEARCHTYPE=message,SEARCH="content:This is test message from zsoap jmeter test to:${TOUSER}")
+PROFILE.ZSOAP.sequence.79=SearchRequest(SEARCHTYPE=message,SEARCH="subject:*ello World")
+PROFILE.ZSOAP.sequence.80=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER} OR in:calendar")
+PROFILE.ZSOAP.sequence.81=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER} AND in:sent")
+PROFILE.ZSOAP.sequence.82=SearchRequest(SEARCHTYPE=conversation,SEARCH="in:inbox")
+PROFILE.ZSOAP.sequence.83=SearchRequest(SEARCHTYPE=conversation,SEARCH="from:user*")
+PROFILE.ZSOAP.sequence.84=SearchRequest(SEARCHTYPE="conversation",SEARCH="subject:Hello World OR subject:Subject of meeting perf zsoap testing")
+PROFILE.ZSOAP.sequence.85=SearchRequest(SEARCHTYPE="appointment,message",SEARCH="in:Calendar")
+PROFILE.ZSOAP.sequence.86=SearchRequest(SEARCHTYPE=message,SEARCH="is:invite not from:${USER}")
 # This request will fail unless the previous search found a message which
 # is probably not likely
-PROFILE.ZSOAP.sequence.74=SendInviteReplyRequest
-PROFILE.ZSOAP.sequence.75=EndSessionRequest
+PROFILE.ZSOAP.sequence.87=SendInviteReplyRequest
+PROFILE.ZSOAP.sequence.88=EndSessionRequest

--- a/tests/generic/zsoap/zsoap.jmx
+++ b/tests/generic/zsoap/zsoap.jmx
@@ -149,6 +149,7 @@
         <stringProp name="soaptest_folderName">soaptest</stringProp>
         <stringProp name="soaptest_tagName">soaptag</stringProp>
         <stringProp name="soaptest_SearchFolderName">soapsearchtest</stringProp>
+        <stringProp name="endDate">0</stringProp>
       </ConfigTestElement>
       <hashTree/>
       <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="ZSOAP HTTP Config" enabled="true">
@@ -202,9 +203,15 @@ vars.put(&quot;URL&quot;,url);</stringProp>
       </ThreadGroup>
       <hashTree>
         <BeanShellSampler guiclass="BeanShellSamplerGui" testclass="BeanShellSampler" testname="randomVariableNameGenerator" enabled="true">
-          <stringProp name="BeanShellSampler.query">vars.put(&quot;soaptest_folderName&quot;,&quot;soaptest_${__Random(1,10000000)}&quot;);
+          <stringProp name="BeanShellSampler.query">import java.text.SimpleDateFormat;
+
+vars.put(&quot;soaptest_folderName&quot;,&quot;soaptest_${__Random(1,10000000)}&quot;);
 vars.put(&quot;soaptest_tagName&quot;,&quot;soaptag_${__Random(1,10000000)}&quot;);
-vars.put(&quot;soaptest_SearchFolderName&quot;,&quot;soapsearchtest_${__Random(1,10000000)}&quot;);</stringProp>
+vars.put(&quot;soaptest_SearchFolderName&quot;,&quot;soapsearchtest_${__Random(1,10000000)}&quot;);
+Date now = new Date();
+Date nowPlus30Minutes = new Date(now.getTime() + 30 * 60 * 1000);
+SimpleDateFormat sdf = new SimpleDateFormat(&quot;yyyyMMdd&apos;T&apos;hhmmss&quot;);
+vars.put(&quot;endDate&quot;,sdf.format(nowPlus30Minutes));</stringProp>
           <stringProp name="BeanShellSampler.filename"></stringProp>
           <stringProp name="BeanShellSampler.parameters"></stringProp>
           <boolProp name="BeanShellSampler.resetInterpreter">false</boolProp>
@@ -391,6 +398,8 @@ if (commands.size() == 0) {
                   <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
                   <boolProp name="HTTPSampler.monitor">false</boolProp>
                   <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+                  <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+                  <stringProp name="HTTPSampler.response_timeout"></stringProp>
                 </HTTPSamplerProxy>
                 <hashTree>
                   <XPathExtractor guiclass="XPathExtractorGui" testclass="XPathExtractor" testname="AUTHTOKEN" enabled="true">
@@ -676,8 +685,8 @@ if (commands.size() == 0) {
           &lt;comp name=&quot;Subject of meeting perf zsoap testing&quot; status=&quot;CONF&quot; fb=&quot;B&quot; allDay=&quot;0&quot; transp=&quot;O&quot;&gt;&#xd;
             &lt;or a=&quot;${USER}@${__P(HTTP.domain)}&quot;&gt;&lt;/or&gt;&#xd;
             &lt;at a=&quot;${TOUSER}@${__P(HTTP.domain)}&quot; rsvp=&quot;1&quot; ptst=&quot;NE&quot; role=&quot;REQ&quot;&gt;&lt;/at&gt;&#xd;
-            &lt;s tz=&quot;(GMT-08.00) Pacific Time (US &amp;amp; Canada) / Tijuana&quot; d=&quot;20180816T040000&quot;&gt;&lt;/s&gt;&#xd;
-            &lt;e d=&quot;20180816T050000&quot; tz=&quot;(GMT-08.00) Pacific Time (US &amp;amp; Canada) / Tijuana&quot;&gt;&lt;/e&gt;&#xd;
+            &lt;s d=&quot;${__time(yyyyMMdd&apos;T&apos;hhmmss)}&quot;&gt;&lt;/s&gt;&#xd;
+            &lt;e d=&quot;${endDate}&quot;&gt;&lt;/e&gt;&#xd;
           &lt;/comp&gt;&#xd;
         &lt;/inv&gt;&#xd;
         &lt;e t=&quot;t&quot; a=&quot;${TOUSER}@${__P(HTTP.domain)}&quot;&gt;&lt;/e&gt;&#xd;


### PR DESCRIPTION
1) Modified create appointment to use currect time stamp.
2) Implemented below search queries:

query="subject:Subject of meeting perf zsoap testing"
query="in:inbox"
query="is:read"
query="subject:Hello World larger:50b"
query="to:${TOUSER}"
query="content:This is test message from zsoap jmeter test to:${TOUSER}"
query="subject:*ello World"
query="to:${TOUSER} OR in:calendar"
query="to:${TOUSER} AND in:sent"
query="in:inbox"
query="from:user*"
query="subject:Hello World OR subject:Subject of meeting perf zsoap testing"
