### PR TITLE
ZCS-6187: Created test_perf.prop for most used soap tests. Also, modi…

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,6 +58,8 @@
     <antcall target="generic-pop"/>
     <antcall target="generic-smtp"/>
     <antcall target="generic-zsoap"/>
+    <antcall target="generic-zsoap-all"/>
+    <antcall target="generic-zsoap-perf"/>
     <antcall target="generic-mix"/>
   </target>
   <target name="fixed">
@@ -184,6 +186,30 @@
       <jmeterarg value="-q${basedir}/${env}"/>
       <jmeterarg value="-q${basedir}/tests/generic/zsoap/load.prop"/>
       <jmeterarg value="-q${basedir}/tests/generic/zsoap/profiles/basic.prop"/>
+    </jmeter>
+  </target>
+  <target name="generic-zsoap-all" depends="src,logs,generic-zsoap">
+    <jmeter jmeterhome="${jmeter.home}"
+            testplan="${basedir}/tests/generic/zsoap/zsoap.jmx"
+            jmeterlogfile="${logs}/generic-zsoap-jmeter.log"
+            resultlog="${logs}/generic-zsoap-requests.log">
+      <property name="ACCOUNTS.csv" value="${users}"/>
+      <property name="user.classpath" value="${zjmeter}"/>
+      <jmeterarg value="-q${basedir}/${env}"/>
+      <jmeterarg value="-q${basedir}/tests/generic/zsoap/load.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/zsoap/profiles/test.prop"/>
+    </jmeter>
+  </target>
+  <target name="generic-zsoap-perf" depends="src,logs,generic-zsoap-all">
+    <jmeter jmeterhome="${jmeter.home}"
+            testplan="${basedir}/tests/generic/zsoap/zsoap.jmx"
+            jmeterlogfile="${logs}/generic-zsoap-jmeter.log"
+            resultlog="${logs}/generic-zsoap-requests.log">
+      <property name="ACCOUNTS.csv" value="${users}"/>
+      <property name="user.classpath" value="${zjmeter}"/>
+      <jmeterarg value="-q${basedir}/${env}"/>
+      <jmeterarg value="-q${basedir}/tests/generic/zsoap/load_perf.prop"/>
+      <jmeterarg value="-q${basedir}/tests/generic/zsoap/profiles/test_perf.prop"/>
     </jmeter>
   </target>
   <target name="generic-mix" depends="src,logs">

--- a/tests/generic/zsoap/load.prop
+++ b/tests/generic/zsoap/load.prop
@@ -1,6 +1,6 @@
 LOAD.duration=130
-LOAD.delay=0
+LOAD.delay=5
 LOAD.ZSOAP.users=1
-LOAD.ZSOAP.userduration=1
+LOAD.ZSOAP.userduration=200
 LOAD.ZSOAP.rampup=0
 LOAD.ZSOAP.loopcount=1

--- a/tests/generic/zsoap/load_perf.prop
+++ b/tests/generic/zsoap/load_perf.prop
@@ -1,0 +1,6 @@
+LOAD.duration=86400
+LOAD.delay=5
+LOAD.ZSOAP.users=100
+LOAD.ZSOAP.userduration=60
+LOAD.ZSOAP.rampup=20
+LOAD.ZSOAP.loopcount=-1

--- a/tests/generic/zsoap/profiles/admin.prop
+++ b/tests/generic/zsoap/profiles/admin.prop
@@ -1,0 +1,12 @@
+PROFILE.ZSOAP.type=sequence
+PROFILE.ZSOAP.sequence.1=GetDomainInfoRequest
+PROFILE.ZSOAP.sequence.2=AuthRequest(AUTHTYPE=admin)
+PROFILE.ZSOAP.sequence.3=GetAccountRequest
+PROFILE.ZSOAP.sequence.4=ModifyAccountRequest
+PROFILE.ZSOAP.sequence.5=GetCosRequest
+PROFILE.ZSOAP.sequence.6=GetAggregateQuotaUsageOnServerRequest
+PROFILE.ZSOAP.sequence.7=FlushCacheRequest
+PROFILE.ZSOAP.sequence.8=GetDataSourcesRequest
+PROFILE.ZSOAP.sequence.9=GetMailboxRequest
+PROFILE.ZSOAP.sequence.10=GetDataSourcesRequest
+

--- a/tests/generic/zsoap/profiles/test.prop
+++ b/tests/generic/zsoap/profiles/test.prop
@@ -1,43 +1,43 @@
 PROFILE.ZSOAP.type=sequence
-PROFILE.ZSOAP.sequence.1=GetDomainInfoRequest
-PROFILE.ZSOAP.sequence.2=AuthRequest(AUTHTYPE=admin)
-PROFILE.ZSOAP.sequence.3=GetAccountRequest
-PROFILE.ZSOAP.sequence.4=ModifyAccountRequest
-PROFILE.ZSOAP.sequence.5=GetCosRequest
-PROFILE.ZSOAP.sequence.6=GetAggregateQuotaUsageOnServerRequest
-PROFILE.ZSOAP.sequence.7=FlushCacheRequest
-PROFILE.ZSOAP.sequence.8=AuthRequest(AUTHTYPE=user)
-PROFILE.ZSOAP.sequence.9=CreateWaitSetRequest
-PROFILE.ZSOAP.sequence.10=WaitSetRequest
-PROFILE.ZSOAP.sequence.11=DestroyWaitSetRequest
-PROFILE.ZSOAP.sequence.12=ModifyFilterRulesRequest
-PROFILE.ZSOAP.sequence.13=GetFilterRulesRequest
-PROFILE.ZSOAP.sequence.14=ApplyFilterRulesRequest
-PROFILE.ZSOAP.sequence.15=CreateAppointmentRequest
-PROFILE.ZSOAP.sequence.16=SearchRequest(SEARCHTYPE=appointment,SEARCH=*)
-PROFILE.ZSOAP.sequence.17=GetAppointmentRequest
-PROFILE.ZSOAP.sequence.18=CreateTagRequest
-PROFILE.ZSOAP.sequence.19=GetTagRequest
-PROFILE.ZSOAP.sequence.20=TagActionRequest(TAGACTIONTYPE=delete)
-PROFILE.ZSOAP.sequence.21=SearchRequest(SEARCHTYPE=message,SEARCH=*)
-PROFILE.ZSOAP.sequence.22=GetMsgRequest
-PROFILE.ZSOAP.sequence.23=MsgActionRequest(MSGACTIONTYPE=read)
-PROFILE.ZSOAP.sequence.24=SetCustomMetadataRequest
-PROFILE.ZSOAP.sequence.25=SearchRequest(SEARCHTYPE=conversation,SEARCH=*)
-PROFILE.ZSOAP.sequence.26=SearchConvRequest
-PROFILE.ZSOAP.sequence.27=GetConvRequest
-PROFILE.ZSOAP.sequence.28=ConvActionRequest
-PROFILE.ZSOAP.sequence.29=GetFolderRequest(PATH=inbox)
-PROFILE.ZSOAP.sequence.30=FolderActionRequest(FOLDERACTIONTYPE=read)
-PROFILE.ZSOAP.sequence.31=CreateContactRequest
-PROFILE.ZSOAP.sequence.32=GetContactsRequest
-PROFILE.ZSOAP.sequence.33=ContactActionRequest
-PROFILE.ZSOAP.sequence.34=ModifyContactRequest
-PROFILE.ZSOAP.sequence.35=GetMiniCalRequest
-PROFILE.ZSOAP.sequence.36=ContactActionRequest
-PROFILE.ZSOAP.sequence.37=GetAccountInfoRequest
-PROFILE.ZSOAP.sequence.38=GetMailboxRequest
-PROFILE.ZSOAP.sequence.39=SyncRequest
+PROFILE.ZSOAP.sequence.1=AuthRequest(AUTHTYPE=user)
+PROFILE.ZSOAP.sequence.2=SendMsgRequest
+PROFILE.ZSOAP.sequence.3=CreateAppointmentRequest
+PROFILE.ZSOAP.sequence.4=CreateTagRequest
+PROFILE.ZSOAP.sequence.5=ModifyFilterRulesRequest
+PROFILE.ZSOAP.sequence.6=CreateContactRequest
+PROFILE.ZSOAP.sequence.7=CreateFolderRequest
+PROFILE.ZSOAP.sequence.8=CreateSearchFolderRequest
+PROFILE.ZSOAP.sequence.9=CreateSignatureRequest
+PROFILE.ZSOAP.sequence.10=SearchRequest(SEARCHTYPE=message,SEARCH="in:inbox")
+PROFILE.ZSOAP.sequence.11=SearchRequest(SEARCHTYPE=appointment,SEARCH="in:Calendar")
+PROFILE.ZSOAP.sequence.12=SearchRequest(SEARCHTYPE=conversation,SEARCH="in:inbox")
+PROFILE.ZSOAP.sequence.13=GetMsgRequest
+PROFILE.ZSOAP.sequence.14=GetAppointmentRequest
+PROFILE.ZSOAP.sequence.15=SearchConvRequest
+PROFILE.ZSOAP.sequence.16=GetTagRequest
+PROFILE.ZSOAP.sequence.17=GetFilterRulesRequest
+PROFILE.ZSOAP.sequence.18=GetContactsRequest
+PROFILE.ZSOAP.sequence.19=GetConvRequest
+PROFILE.ZSOAP.sequence.20=MsgActionRequest(MSGACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.21=MsgActionRequest(MSGACTIONTYPE=flag)
+PROFILE.ZSOAP.sequence.22=MsgActionRequest(MSGACTIONTYPE=tag)
+PROFILE.ZSOAP.sequence.23=MsgActionRequest(MSGACTIONTYPE=unread)
+PROFILE.ZSOAP.sequence.24=MsgActionRequest(MSGACTIONTYPE=trash)
+PROFILE.ZSOAP.sequence.25=MsgActionRequest(MSGACTIONTYPE=unflag)
+PROFILE.ZSOAP.sequence.26=MsgActionRequest(MSGACTIONTYPE=move)
+PROFILE.ZSOAP.sequence.27=MsgActionRequest(MSGACTIONTYPE=delete)
+PROFILE.ZSOAP.sequence.28=ConvActionRequest(CONVACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.29=ConvActionRequest(CONVACTIONTYPE=trash)
+PROFILE.ZSOAP.sequence.30=ConvActionRequest(CONVACTIONTYPE=move)
+PROFILE.ZSOAP.sequence.31=ConvActionRequest(CONVACTIONTYPE=delete)
+PROFILE.ZSOAP.sequence.32=SetCustomMetadataRequest
+PROFILE.ZSOAP.sequence.33=GetFolderRequest(PATH=inbox)
+PROFILE.ZSOAP.sequence.34=FolderActionRequest(FOLDERACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.35=ContactActionRequest
+PROFILE.ZSOAP.sequence.36=ModifyContactRequest
+PROFILE.ZSOAP.sequence.37=GetMiniCalRequest
+PROFILE.ZSOAP.sequence.38=GetAccountInfoRequest
+PROFILE.ZSOAP.sequence.39=ApplyFilterRulesRequest
 PROFILE.ZSOAP.sequence.40=CheckSpellingRequest
 PROFILE.ZSOAP.sequence.41=SetMailboxMetadataRequest
 PROFILE.ZSOAP.sequence.42=DismissCalendarItemAlarmRequest
@@ -45,47 +45,70 @@ PROFILE.ZSOAP.sequence.43=GetAvailableLocalesRequest
 PROFILE.ZSOAP.sequence.44=AutoCompleteRequest
 PROFILE.ZSOAP.sequence.45=GetAvailableSkinsRequest
 PROFILE.ZSOAP.sequence.46=BrowseRequest
-PROFILE.ZSOAP.sequence.47=SyncGalRequest
-PROFILE.ZSOAP.sequence.48=GetPrefsRequest
-PROFILE.ZSOAP.sequence.49=SnoozeCalendarItemAlarmRequest
-PROFILE.ZSOAP.sequence.50=NoOpRequest
-PROFILE.ZSOAP.sequence.51=SaveDraftRequest
-PROFILE.ZSOAP.sequence.52=ModifyPrefsRequest
-PROFILE.ZSOAP.sequence.53=DiscoverRightsRequest
-PROFILE.ZSOAP.sequence.54=GetDataSourcesRequest
-PROFILE.ZSOAP.sequence.55=GetMailboxMetadataRequest
-PROFILE.ZSOAP.sequence.56=GetShareInfoRequest
-PROFILE.ZSOAP.sequence.57=GetFreeBusyRequest
-PROFILE.ZSOAP.sequence.58=GetAvailableCsvFormatsRequest
-PROFILE.ZSOAP.sequence.59=CreateSearchFolderRequest
-PROFILE.ZSOAP.sequence.60=GetFolderRequest(PATH=SearchFolderRequest)
-PROFILE.ZSOAP.sequence.61=FolderActionRequest(FOLDERACTIONTYPE=delete)
-PROFILE.ZSOAP.sequence.62=SendMsgRequest
-PROFILE.ZSOAP.sequence.63=SearchRequest(SEARCHTYPE=message,SEARCH=*)
-PROFILE.ZSOAP.sequence.64=SendDeliveryReportRequest
-PROFILE.ZSOAP.sequence.65=CreateFolderRequest
-PROFILE.ZSOAP.sequence.66=GetFolderRequest(PATH=FolderRequest)
-PROFILE.ZSOAP.sequence.67=FolderActionRequest(FOLDERACTIONTYPE=delete)
-PROFILE.ZSOAP.sequence.68=GetRightsRequest
-PROFILE.ZSOAP.sequence.69=GetWhiteBlackListRequest
-PROFILE.ZSOAP.sequence.70=ModifyAccountRequest
-PROFILE.ZSOAP.sequence.71=RankingActionRequest
-PROFILE.ZSOAP.sequence.72=GetInfoRequest
-PROFILE.ZSOAP.sequence.73=SearchRequest(SEARCHTYPE=appointment,SEARCH="subject:Subject of meeting perf zsoap testing")
-PROFILE.ZSOAP.sequence.74=SearchRequest(SEARCHTYPE=message,SEARCH="in:inbox")
-PROFILE.ZSOAP.sequence.75=SearchRequest(SEARCHTYPE=message,SEARCH="is:read")
-PROFILE.ZSOAP.sequence.76=SearchRequest(SEARCHTYPE=message,SEARCH="subject:Hello World larger:50b")
-PROFILE.ZSOAP.sequence.77=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER}")
-PROFILE.ZSOAP.sequence.78=SearchRequest(SEARCHTYPE=message,SEARCH="content:This is test message from zsoap jmeter test to:${TOUSER}")
-PROFILE.ZSOAP.sequence.79=SearchRequest(SEARCHTYPE=message,SEARCH="subject:*ello World")
-PROFILE.ZSOAP.sequence.80=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER} OR in:calendar")
-PROFILE.ZSOAP.sequence.81=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER} AND in:sent")
-PROFILE.ZSOAP.sequence.82=SearchRequest(SEARCHTYPE=conversation,SEARCH="in:inbox")
-PROFILE.ZSOAP.sequence.83=SearchRequest(SEARCHTYPE=conversation,SEARCH="from:user*")
-PROFILE.ZSOAP.sequence.84=SearchRequest(SEARCHTYPE="conversation",SEARCH="subject:Hello World OR subject:Subject of meeting perf zsoap testing")
-PROFILE.ZSOAP.sequence.85=SearchRequest(SEARCHTYPE="appointment,message",SEARCH="in:Calendar")
-PROFILE.ZSOAP.sequence.86=SearchRequest(SEARCHTYPE=message,SEARCH="is:invite not from:${USER}")
-# This request will fail unless the previous search found a message which
-# is probably not likely
-PROFILE.ZSOAP.sequence.87=SendInviteReplyRequest
-PROFILE.ZSOAP.sequence.88=EndSessionRequest
+PROFILE.ZSOAP.sequence.47=GetPrefsRequest
+PROFILE.ZSOAP.sequence.48=SnoozeCalendarItemAlarmRequest
+PROFILE.ZSOAP.sequence.49=NoOpRequest
+PROFILE.ZSOAP.sequence.50=SaveDraftRequest
+PROFILE.ZSOAP.sequence.51=ModifyPrefsRequest
+PROFILE.ZSOAP.sequence.52=DiscoverRightsRequest
+PROFILE.ZSOAP.sequence.53=GetMailboxMetadataRequest
+PROFILE.ZSOAP.sequence.54=GetShareInfoRequest
+PROFILE.ZSOAP.sequence.55=GetFreeBusyRequest
+PROFILE.ZSOAP.sequence.56=GetAvailableCsvFormatsRequest
+PROFILE.ZSOAP.sequence.57=SendDeliveryReportRequest
+PROFILE.ZSOAP.sequence.58=SearchRequest(SEARCHTYPE=message,SEARCH="in:inbox")
+PROFILE.ZSOAP.sequence.59=MsgActionRequest(MSGACTIONTYPE=tag)
+PROFILE.ZSOAP.sequence.60=TagActionRequest(TAGACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.61=TagActionRequest(TAGACTIONTYPE=rename)
+PROFILE.ZSOAP.sequence.62=TagActionRequest(TAGACTIONTYPE=delete)
+PROFILE.ZSOAP.sequence.63=GetFolderRequest(PATH=SearchFolderRequest)
+PROFILE.ZSOAP.sequence.64=FolderActionRequest(FOLDERACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.65=FolderActionRequest(FOLDERACTIONTYPE=color)
+PROFILE.ZSOAP.sequence.66=FolderActionRequest(FOLDERACTIONTYPE=move)
+PROFILE.ZSOAP.sequence.67=FolderActionRequest(FOLDERACTIONTYPE=empty)
+PROFILE.ZSOAP.sequence.68=FolderActionRequest(FOLDERACTIONTYPE=trash)
+PROFILE.ZSOAP.sequence.69=FolderActionRequest(FOLDERACTIONTYPE=rename)
+PROFILE.ZSOAP.sequence.70=FolderActionRequest(FOLDERACTIONTYPE=delete)
+PROFILE.ZSOAP.sequence.71=GetFolderRequest(PATH=FolderRequest)
+PROFILE.ZSOAP.sequence.72=FolderActionRequest(FOLDERACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.73=FolderActionRequest(FOLDERACTIONTYPE=color)
+PROFILE.ZSOAP.sequence.74=FolderActionRequest(FOLDERACTIONTYPE=move)
+PROFILE.ZSOAP.sequence.75=FolderActionRequest(FOLDERACTIONTYPE=empty)
+PROFILE.ZSOAP.sequence.76=FolderActionRequest(FOLDERACTIONTYPE=trash)
+PROFILE.ZSOAP.sequence.77=FolderActionRequest(FOLDERACTIONTYPE=rename)
+PROFILE.ZSOAP.sequence.78=FolderActionRequest(FOLDERACTIONTYPE=delete)
+PROFILE.ZSOAP.sequence.79=SearchRequest(SEARCHTYPE=message,SEARCH="is:read")
+PROFILE.ZSOAP.sequence.80=SearchRequest(SEARCHTYPE=message,SEARCH="subject:Hello World larger:50b")
+PROFILE.ZSOAP.sequence.81=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER}")
+PROFILE.ZSOAP.sequence.82=SearchRequest(SEARCHTYPE=message,SEARCH="content:This is test message from zsoap jmeter test to:${TOUSER}")
+PROFILE.ZSOAP.sequence.83=SearchRequest(SEARCHTYPE=message,SEARCH="subject:*ello World")
+PROFILE.ZSOAP.sequence.84=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER} OR in:calendar")
+PROFILE.ZSOAP.sequence.85=SearchRequest(SEARCHTYPE=message,SEARCH="to:${TOUSER} AND in:sent")
+PROFILE.ZSOAP.sequence.86=SearchRequest(SEARCHTYPE=conversation,SEARCH="from:user*")
+PROFILE.ZSOAP.sequence.87=SearchRequest(SEARCHTYPE="conversation",SEARCH="subject:Hello World OR subject:Subject of meeting perf zsoap testing")
+PROFILE.ZSOAP.sequence.88=SearchRequest(SEARCHTYPE="appointment,message",SEARCH="in:Calendar")
+PROFILE.ZSOAP.sequence.89=GetRightsRequest
+PROFILE.ZSOAP.sequence.90=GetWhiteBlackListRequest
+PROFILE.ZSOAP.sequence.91=RankingActionRequest
+PROFILE.ZSOAP.sequence.92=GetInfoRequest
+PROFILE.ZSOAP.sequence.93=SearchRequest(SEARCHTYPE=message,SEARCH="is:invite not from:${USER}")
+PROFILE.ZSOAP.sequence.94=SendInviteReplyRequest
+PROFILE.ZSOAP.sequence.95=GetSignaturesRequest
+PROFILE.ZSOAP.sequence.96=EndSessionRequest
+##Below are Admin soap requests, same are available in admin.prop file
+#PROFILE.ZSOAP.sequence.1=GetDomainInfoRequest
+#PROFILE.ZSOAP.sequence.2=AuthRequest(AUTHTYPE=admin)
+#PROFILE.ZSOAP.sequence.3=GetAccountRequest
+#PROFILE.ZSOAP.sequence.4=ModifyAccountRequest
+#PROFILE.ZSOAP.sequence.5=GetCosRequest
+#PROFILE.ZSOAP.sequence.6=GetAggregateQuotaUsageOnServerRequest
+#PROFILE.ZSOAP.sequence.7=FlushCacheRequest
+#PROFILE.ZSOAP.sequence.8=GetDataSourcesRequest
+#PROFILE.ZSOAP.sequence.9=GetMailboxRequest
+#PROFILE.ZSOAP.sequence.10=GetDataSourcesRequest
+##Below requests are currently commented, though can be included in feature e.g. WaitSet, Sync, SyncGAL feature related
+#PROFILE.ZSOAP.sequence.1=CreateWaitSetRequest
+#PROFILE.ZSOAP.sequence.2=WaitSetRequest
+#PROFILE.ZSOAP.sequence.3=DestroyWaitSetRequest
+#PROFILE.ZSOAP.sequence.4=SyncRequest
+#PROFILE.ZSOAP.sequence.5=SyncGalRequest

--- a/tests/generic/zsoap/profiles/test_perf.prop
+++ b/tests/generic/zsoap/profiles/test_perf.prop
@@ -1,0 +1,31 @@
+PROFILE.ZSOAP.type=sequence
+PROFILE.ZSOAP.sequence.1=AuthRequest(AUTHTYPE=user)
+PROFILE.ZSOAP.sequence.2=SendMsgRequest
+PROFILE.ZSOAP.sequence.3=GetInfoRequest
+PROFILE.ZSOAP.sequence.4=NoOpRequest
+PROFILE.ZSOAP.sequence.5=SearchRequest(SEARCHTYPE=message,SEARCH="in:inbox JMeter*")
+PROFILE.ZSOAP.sequence.6=SearchRequest(SEARCHTYPE=conversation,SEARCH="to:${TOUSER} AND in:sent")
+PROFILE.ZSOAP.sequence.7=GetMsgRequest
+PROFILE.ZSOAP.sequence.8=GetInfoRequest
+PROFILE.ZSOAP.sequence.9=NoOpRequest
+PROFILE.ZSOAP.sequence.10=MsgActionRequest(MSGACTIONTYPE=trash)
+PROFILE.ZSOAP.sequence.11=SearchRequest(SEARCHTYPE=message,SEARCH="Choice")
+PROFILE.ZSOAP.sequence.12=GetMsgRequest
+PROFILE.ZSOAP.sequence.13=MsgActionRequest(MSGACTIONTYPE=flag)
+PROFILE.ZSOAP.sequence.14=SearchRequest(SEARCHTYPE=message,SEARCH="not Choice")
+PROFILE.ZSOAP.sequence.15=GetMsgRequest
+PROFILE.ZSOAP.sequence.16=SearchRequest(SEARCHTYPE=message,SEARCH="is:flagged")
+PROFILE.ZSOAP.sequence.17=GetInfoRequest
+PROFILE.ZSOAP.sequence.18=NoOpRequest
+PROFILE.ZSOAP.sequence.19=GetAvailableSkinsRequest
+PROFILE.ZSOAP.sequence.20=SaveDraftRequest
+PROFILE.ZSOAP.sequence.21=GetMailboxMetadataRequest
+PROFILE.ZSOAP.sequence.22=GetFolderRequest
+PROFILE.ZSOAP.sequence.23=GetAvailableLocalesRequest
+PROFILE.ZSOAP.sequence.24=DiscoverRightsRequest
+PROFILE.ZSOAP.sequence.25=GetMiniCalRequest
+PROFILE.ZSOAP.sequence.26=SearchConvRequest
+PROFILE.ZSOAP.sequence.27=GetContactsRequest
+PROFILE.ZSOAP.sequence.28=AutoCompleteRequest
+PROFILE.ZSOAP.sequence.29=ConvActionRequest(CONVACTIONTYPE=read)
+PROFILE.ZSOAP.sequence.30=EndSessionRequest

--- a/tests/generic/zsoap/zsoap.jmx
+++ b/tests/generic/zsoap/zsoap.jmx
@@ -287,6 +287,21 @@ if (commands.size() &gt; 0) {
       vars.put(&quot;TAGACTIONTYPE&quot;,&quot;read&quot;);
     }
   }
+  if (c.getName().equals(&quot;MsgActionRequest&quot;)) {
+    if (c.getArg(&quot;MSGACTIONTYPE&quot;) == null) {
+      vars.put(&quot;MSGACTIONTYPE&quot;,&quot;read&quot;);
+    }
+  }
+  if (c.getName().equals(&quot;ConvActionRequest&quot;)) {
+    if (c.getArg(&quot;CONVACTIONTYPE&quot;) == null) {
+      vars.put(&quot;CONVACTIONTYPE&quot;,&quot;read&quot;);
+    }
+  }
+  if (c.getName().equals(&quot;SearchRequest&quot;)) {
+    if (c.getArg(&quot;SEARCHTYPE&quot;) == null) {
+      vars.put(&quot;SEARCHTYPE&quot;,&quot;message&quot;);
+    }
+  }
   //log.info(vars.get(&quot;COMMAND&quot;));
 }
 if (commands.size() == 0) {


### PR DESCRIPTION
**Changes:**

- Created test_perf.prop for most used soap tests (See ZCS-5983 and ZCS-6098)
- Also, modified test.prop to include **all** soap tests 
- Commented admin related tests in test.prop file and added admin.prop for admin only tests.
- Added target for running basic.prop, test.prop tests once as per loopcount in load.prop, followed by test_perf.prop tests execution multiple times as per loopcount in load_perf.prop
- Also, modified zsoap.jmx file to provide default values for MsgActionRequest, ConvActionRequest, SearchRequest tests.
